### PR TITLE
make_list_with_nulls_bug1009 fix

### DIFF
--- a/src/Parsers/Kusto/KQL_ReleaseNote.md
+++ b/src/Parsers/Kusto/KQL_ReleaseNote.md
@@ -650,7 +650,7 @@ https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/make-seriesoper
    `Customers | summarize t = make_list_if(FirstName, Age > 10) by FirstName`
    `Customers | summarize t = make_list_if(FirstName, Age > 10, 10) by FirstName`
  - [make_list_with_nulls()](https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/make-list-with-nulls-aggfunction)  
-   `Customers | summarize t = make_list_with_nulls(FirstName) by FirstName`
+   `Customers | summarize t = make_list_with_nulls(Age) by FirstName`
  - [make_set()](https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/makeset-aggfunction)  
    `Customers | summarize t = make_set(FirstName) by FirstName`
    `Customers | summarize t = make_set(FirstName, 10) by FirstName`

--- a/src/Parsers/Kusto/KustoFunctions/KQLAggregationFunctions.cpp
+++ b/src/Parsers/Kusto/KustoFunctions/KQLAggregationFunctions.cpp
@@ -152,7 +152,14 @@ bool MakeListIf::convertImpl(String & out,IParser::Pos & pos)
 
 bool MakeListWithNulls::convertImpl(String & out,IParser::Pos & pos)
 {
-    return directMapping(out,pos,"groupArray");
+    String fn_name = getKQLFunctionName(pos);
+
+    if (fn_name.empty())
+        return false;
+    ++pos;
+    const auto column_name = getConvertedArgument(fn_name,pos);
+    out = "arrayConcat(groupArray(" + column_name + ") AS ga, arrayMap(x -> null, range(0, toUInt32(count(*)-length(ga)),1)))";
+    return true;
 }
 
 bool MakeSet::convertImpl(String & out,IParser::Pos & pos)

--- a/src/Parsers/tests/KQL/gtest_KQL_AggregateFunctions.cpp
+++ b/src/Parsers/tests/KQL/gtest_KQL_AggregateFunctions.cpp
@@ -53,5 +53,9 @@ INSTANTIATE_TEST_SUITE_P(ParserKQLQuery, ParserTest,
         {
             "DataTable | summarize t = percentilew(Bucket, Frequency, 50)",
             "SELECT quantileExactWeighted(50 / 100)(Bucket, Frequency) AS t\nFROM DataTable"
+        },
+        {
+             "Customers | summarize t = make_list_with_nulls(Age) by FirstName",
+             "SELECT\n    FirstName,\n    arrayConcat(groupArray(Age) AS ga, arrayMap(x -> NULL, range(0, toUInt32(count(*) - length(ga)), 1))) AS t\nFROM Customers\nGROUP BY FirstName"
         }
 })));


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

Bug fix for `make_list_with_nulls`:  
input query: `Customers | summarize t = make_list_with_nulls(Age) by FirstName` 
output: 
┌─FirstName─┬─t─────────────────────────┐    

│ bbb       │ [20,10,NULL,NULL]         │ 
│ ccc       │ [3,1,2,NULL,NULL,NULL]    │
│ aaa       │ [200,100,200,300,300,100] │
└───────────┴───────────────────────────┘

Note: please use non-string columns because KQL doesn't support NULL for string datatype.  
Also, `the order of NULL is not defined because If the input to the summarize operator is not sorted, the order of elements in the resulting array is undefined.`

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
