### PR TITLE
strcat fix for numbers

### DIFF
--- a/src/Parsers/tests/KQL/gtest_KQL_StringFunctions.cpp
+++ b/src/Parsers/tests/KQL/gtest_KQL_StringFunctions.cpp
@@ -161,5 +161,9 @@ INSTANTIATE_TEST_SUITE_P(ParserKQLQuery_String, ParserTest,
         {
             "print bin(datetime(1970-05-11 13:45:07.456345672), 1microseconds)",
             "SELECT toDateTime64(toInt64(toFloat64(parseDateTime64BestEffortOrNull('1970-05-11 13:45:07.456345672', 9, 'UTC')) / 0.000001) * 0.000001, 9, 'UTC')"
+        },
+        {
+            "print strcat(1, '-', 2, '!~', 3, '***', 4.5)",
+            "SELECT concat('1', '-', '2', '!~', '3', '***', '4.5')"
         }
 })));


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)
### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...
Improved `strcat` so that it works with numbers.  
Example Query: `print strcat(1, '-', 2, '!~', 3, '***', 4.5)`
output: `1-2!~3***4.5`

*Note: `strcat` still need to be improved to work for dates and times.*
> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
