### PR TITLE
endofyear() bug_fix_1369

### DIFF
--- a/src/Parsers/Kusto/KustoFunctions/KQLDateTimeFunctions.cpp
+++ b/src/Parsers/Kusto/KustoFunctions/KQLDateTimeFunctions.cpp
@@ -230,21 +230,27 @@ bool EndOfWeek::convertImpl(String & out, IParser::Pos & pos)
 
 bool EndOfYear::convertImpl(String & out, IParser::Pos & pos)
 {
-    
     const String fn_name = getKQLFunctionName(pos);
     if (fn_name.empty())
         return false;
 
     ++pos;
     const String datetime_str = getConvertedArgument(fn_name, pos);
-    String offset = "0";
 
+    if(datetime_str.empty())
+        throw Exception("Number of arguments do not match in function:" + fn_name, ErrorCodes::SYNTAX_ERROR);
+
+    String offset = "0";
     if (pos->type == TokenType::Comma)
     {
          ++pos;
          offset = getConvertedArgument(fn_name, pos);
+         if(offset.empty())
+            throw Exception("Number of arguments do not match in function:" + fn_name, ErrorCodes::SYNTAX_ERROR);
+         offset.erase(remove(offset.begin(), offset.end(), ' '), offset.end());
     }
-        out = std::format("toDateTime(toStartOfDay({}),9,'UTC') + (INTERVAL {} +1 YEAR) - (INTERVAL 1 microsecond)", datetime_str, toString(offset));
+
+        out = std::format("(((((toDateTime(toString(toLastDayOfMonth(toDateTime({0}, 9, 'UTC') + toIntervalYear({1}) + toIntervalMonth(12 - toInt8(substring(toString(toDateTime({0}, 9, 'UTC')), 6, 2))))), 9, 'UTC') + toIntervalHour(23)) + toIntervalMinute(59)) + toIntervalSecond(60)) - toIntervalMicrosecond(1)))", datetime_str, toString(offset));
 
     return true;
 }

--- a/src/Parsers/tests/KQL/gtest_KQL_dateTimeFunctions.cpp
+++ b/src/Parsers/tests/KQL/gtest_KQL_dateTimeFunctions.cpp
@@ -96,11 +96,11 @@ INSTANTIATE_TEST_SUITE_P(ParserKQLQuery_Datetime, ParserTest,
         },
         {
             "print endofyear(datetime(2017-01-01 10:10:17), -1) ",
-            "SELECT (toDateTime(toStartOfDay(parseDateTime64BestEffortOrNull('2017-01-01 10:10:17', 9, 'UTC')), 9, 'UTC') + toIntervalYear(-1 + 1)) - toIntervalMicrosecond(1)"
+            "SELECT (((toDateTime(toString(toLastDayOfMonth((toDateTime(parseDateTime64BestEffortOrNull('2017-01-01 10:10:17', 9, 'UTC'), 9, 'UTC') + toIntervalYear(-1)) + toIntervalMonth(12 - toInt8(substring(toString(toDateTime(parseDateTime64BestEffortOrNull('2017-01-01 10:10:17', 9, 'UTC'), 9, 'UTC')), 6, 2))))), 9, 'UTC') + toIntervalHour(23)) + toIntervalMinute(59)) + toIntervalSecond(60)) - toIntervalMicrosecond(1)"
         },
         {
            "print endofyear(datetime(2017-01-01 10:10:17), 1)" ,
-           "SELECT (toDateTime(toStartOfDay(parseDateTime64BestEffortOrNull('2017-01-01 10:10:17', 9, 'UTC')), 9, 'UTC') + toIntervalYear(1 + 1)) - toIntervalMicrosecond(1)"
+           "SELECT (((toDateTime(toString(toLastDayOfMonth((toDateTime(parseDateTime64BestEffortOrNull('2017-01-01 10:10:17', 9, 'UTC'), 9, 'UTC') + toIntervalYear(1)) + toIntervalMonth(12 - toInt8(substring(toString(toDateTime(parseDateTime64BestEffortOrNull('2017-01-01 10:10:17', 9, 'UTC'), 9, 'UTC')), 6, 2))))), 9, 'UTC') + toIntervalHour(23)) + toIntervalMinute(59)) + toIntervalSecond(60)) - toIntervalMicrosecond(1)"
         },
         {
             "print make_datetime(2017,10,01)",


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

current input output:
```
print endofyear(datetime(2017-01-01 10:10:17), 1);
2018-12-31 23:59:59.999999000

print endofyear(datetime(2017-01-01 10:10:17), -4);
2013-12-31 23:59:59.999999000
```
> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
