### PR TITLE
WeakHash32 Collision Fix

### DIFF
--- a/cmake/cpu_features.cmake
+++ b/cmake/cpu_features.cmake
@@ -62,7 +62,7 @@ elseif (ARCH_AARCH64)
 
 elseif (ARCH_PPC64LE)
     # Note that gcc and clang have support for x86 SSE2 intrinsics when building for PowerPC
-    set (COMPILER_FLAGS "${COMPILER_FLAGS} -maltivec -mcpu=power8 -D__SSE2__=1 -DNO_WARN_X86_INTRINSICS")
+    set (COMPILER_FLAGS "${COMPILER_FLAGS} -maltivec -mcpu=power8 -D__SSE2__=1 -DNO_WARN_X86_INTRINSICS -DHAVE_POWER8=1 -DHAS_ALTIVEC=1"")
 
 elseif (ARCH_AMD64)
     option (ENABLE_SSSE3 "Use SSSE3 instructions on x86_64" 1)

--- a/contrib/rocksdb-cmake/CMakeLists.txt
+++ b/contrib/rocksdb-cmake/CMakeLists.txt
@@ -543,4 +543,4 @@ add_library(_rocksdb ${SOURCES})
 add_library(ch_contrib::rocksdb ALIAS _rocksdb)
 target_link_libraries(_rocksdb PRIVATE ${THIRDPARTY_LIBS} ${SYSTEM_LIBS})
 # SYSTEM is required to overcome some issues
-target_include_directories(_rocksdb SYSTEM BEFORE INTERFACE "${ROCKSDB_SOURCE_DIR}/include")
+target_include_directories(_rocksdb SYSTEM BEFORE INTERFACE "${ROCKSDB_SOURCE_DIR}/include" "${ROCKSDB_SOURCE_DIR}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -366,6 +366,7 @@ endif ()
 
 target_link_libraries(clickhouse_common_io PUBLIC ch_contrib::re2_st)
 target_link_libraries(clickhouse_common_io PUBLIC ch_contrib::re2)
+target_link_libraries(clickhouse_common_io PUBLIC ch_contrib::rocksdb)
 
 target_link_libraries(clickhouse_common_io
         PUBLIC

--- a/src/Common/HashTable/Hash.h
+++ b/src/Common/HashTable/Hash.h
@@ -7,7 +7,8 @@
 #include <base/StringRef.h>
 
 #include <type_traits>
-
+#include <util/crc32c_ppc.h>
+#include <Common/config.h>
 
 /** Hash functions that are better than the trivial function std::hash.
   *
@@ -66,6 +67,8 @@ inline DB::UInt64 intHashCRC32(DB::UInt64 x, DB::UInt64 updated_value)
     return _mm_crc32_u64(updated_value, x);
 #elif defined(__aarch64__) && defined(__ARM_FEATURE_CRC32)
     return  __crc32cd(updated_value, x);
+#elif defined(ARCH_PPC64LE)
+    return crc32c_ppc(updated_value, reinterpret_cast<const unsigned char *>(&x), sizeof(x));
 #else
     /// On other platforms we do not have CRC32. NOTE This can be confusing.
     return intHash64(x) ^ updated_value;

--- a/src/Common/config.h.in
+++ b/src/Common/config.h.in
@@ -52,3 +52,4 @@
 #cmakedefine01 USE_ODBC
 #cmakedefine01 USE_BORINGSSL
 #cmakedefine01 USE_BLAKE3
+#cmakedefine01 ARCH_PPC64LE

--- a/src/configure_config.cmake
+++ b/src/configure_config.cmake
@@ -138,3 +138,7 @@ endif()
 if (NOT ENABLE_EXTERNAL_OPENSSL)
     set(USE_BORINGSSL 1)
 endif ()
+if (ARCH_PPC64LE)
+    set (ARCH_PPC64LE 1)
+endif()
+


### PR DESCRIPTION
 In case of power, the function crc32_vpmsum will be used for the CRC32 generation


### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
