### PR TITLE
bug fix 1528

### DIFF
--- a/src/Parsers/Kusto/KustoFunctions/KQLDynamicFunctions.cpp
+++ b/src/Parsers/Kusto/KustoFunctions/KQLDynamicFunctions.cpp
@@ -377,7 +377,7 @@ bool Zip::convertImpl(String & out, IParser::Pos & pos)
                 lengths.append(i > 0 ? ", " : "");
                 lengths.append(std::format(
                     "length(if(match(toTypeName({0}), 'Array\\(Nullable\\(.*\\)\\)'), {0}, "
-                    "cast({0}, concat('Array(Nullable(', extract(toTypeName({0}), 'Array\\((.*)\\)'), '))'))) as arg{1}_{2})",
+                    "cast({0}, concat('Array(', extract(toTypeName({0}), 'Array\\((.*)\\)'), ')'))) as arg{1}_{2})",
                     arguments[i],
                     i,
                     unique_identifier));


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...
Fixed bug 1528.
Current input output:
```
print zip(repeat(1,4), repeat(2,4));
[[1,2],[1,2],[1,2],[1,2]]
```

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
