### PR TITLE
Fix CityHash endian issue for s390x

### DIFF
--- a/contrib/cityhash102/src/config.h
+++ b/contrib/cityhash102/src/config.h
@@ -68,7 +68,7 @@
 
 /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
    significant byte first (like Motorola and SPARC, unlike Intel). */
-#if defined AC_APPLE_UNIVERSAL_BUILD
+#if defined(AC_APPLE_UNIVERSAL_BUILD) || defined(__s390x__)
 # if defined __BIG_ENDIAN__
 #  define WORDS_BIGENDIAN 1
 # endif


### PR DESCRIPTION
Fix CityHash endian issue for s390x by adding macro.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
Fix CityHash endian issue for s390x
### Changelog category (leave one):

- Build Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed CityHash endian issue for s390x


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
