### PR TITLE
Fix setting TCP_KEEPIDLE of client connection for s390x

### DIFF
--- a/contrib/cityhash102/src/config.h
+++ b/contrib/cityhash102/src/config.h
@@ -68,7 +68,7 @@
 
 /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
    significant byte first (like Motorola and SPARC, unlike Intel). */
-#if defined AC_APPLE_UNIVERSAL_BUILD
+#if defined(AC_APPLE_UNIVERSAL_BUILD) || defined(__s390x__)
 # if defined __BIG_ENDIAN__
 #  define WORDS_BIGENDIAN 1
 # endif


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
In s390x, the code for setting TCP_KEEPIDLE by using Socket::setOption(int level, int option, const Poco::Timespan& value) throws exception (Invalid Argument Exception due to errno 22).
This function passes 16 bytes of buffer which cannot be accepted by s390x.
The fix is to use Socket::setOption(int level, int option, int value), which will pass an int address of value to setsockopt(). This is also the correct way for other platforms when setting TCP_KEEPIDLE, see the similar code in:

https://clickhouse.com/codebrowser/ClickHouse/contrib/libuv/src/unix/tcp.c.html#uv__tcp_keepalive

### Changelog category (leave one):

- Build Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix setting TCP_KEEPIDLE of client connection for s390x


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
