### PR TITLE
Fix transform endian issue for s390x

### DIFF
--- a/src/Functions/transform.cpp
+++ b/src/Functions/transform.cpp
@@ -853,7 +853,12 @@ private:
         {
             const auto * it = table.find(bit_cast<UInt64>(src[i]));
             if (it)
-                memcpy(&dst[i], &it->getMapped(), sizeof(dst[i]));    /// little endian.
+            {
+                if (std::endian::native == std::endian::little)
+                    memcpy(&dst[i], &it->getMapped(), sizeof(dst[i]));
+                else
+                    memcpy(&dst[i], reinterpret_cast<const char *>(&it->getMapped()) + sizeof(UInt64) - sizeof(dst[i]), sizeof(dst[i]));
+            }
             else
                 dst[i] = dst_default;
         }
@@ -869,7 +874,12 @@ private:
         {
             const auto * it = table.find(bit_cast<UInt64>(src[i]));
             if (it)
-                memcpy(&dst[i], &it->getMapped(), sizeof(dst[i]));    /// little endian.
+            {
+                if (std::endian::native == std::endian::little)
+                    memcpy(&dst[i], &it->getMapped(), sizeof(dst[i]));
+                else
+                    memcpy(&dst[i], reinterpret_cast<const char *>(&it->getMapped()) + sizeof(UInt64) - sizeof(dst[i]), sizeof(dst[i]));
+            }
             else if constexpr (is_decimal<U>)
                 dst[i] = static_cast<typename U::NativeType>(dst_default[i]);
             else
@@ -887,7 +897,12 @@ private:
         {
             const auto * it = table.find(bit_cast<UInt64>(src[i]));
             if (it)
-                memcpy(&dst[i], &it->getMapped(), sizeof(dst[i]));
+            {
+                if (std::endian::native == std::endian::little)
+                    memcpy(&dst[i], &it->getMapped(), sizeof(dst[i]));
+                else
+                    memcpy(&dst[i], reinterpret_cast<const char *>(&it->getMapped()) + sizeof(UInt64) - sizeof(dst[i]), sizeof(dst[i]));
+            }
             else
                 dst[i] = src[i];
         }
@@ -958,7 +973,12 @@ private:
             current_src_offset = src_offsets[i];
             const auto * it = table.find(ref);
             if (it)
-                memcpy(&dst[i], &it->getMapped(), sizeof(dst[i]));
+            {
+                if (std::endian::native == std::endian::little)
+                    memcpy(&dst[i], &it->getMapped(), sizeof(dst[i]));
+                else
+                    memcpy(&dst[i], reinterpret_cast<const char *>(&it->getMapped()) + sizeof(UInt64) - sizeof(dst[i]), sizeof(dst[i]));
+            }
             else
                 dst[i] = dst_default;
         }
@@ -979,7 +999,12 @@ private:
             current_src_offset = src_offsets[i];
             const auto * it = table.find(ref);
             if (it)
-                memcpy(&dst[i], &it->getMapped(), sizeof(dst[i]));
+            {
+                if (std::endian::native == std::endian::little)
+                    memcpy(&dst[i], &it->getMapped(), sizeof(dst[i]));
+                else
+                    memcpy(&dst[i], reinterpret_cast<const char *>(&it->getMapped()) + sizeof(UInt64) - sizeof(dst[i]), sizeof(dst[i]));
+            }
             else if constexpr (is_decimal<U>)
                 dst[i] = static_cast<typename U::NativeType>(dst_default[i]);
             else


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
On s390x, the following functional tests fail:
```
00153_transform
00165_transform_non_const_default
01324_if_transform_strings_to_enum
01747_transform_empty_arrays
02125_transform_decimal_bug
```
The root of cause is that there is an endian issue in methods executeImplXXX() in src/Functions/transform.cpp which can only handle little-endian numbers. On big endian machines like s390x, the offsets of source in memcpy method call are incorrect.

The fix is to calculate correct offsets before calling memory on big endian machines.

### Changelog category (leave one):
- Build Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed endian issues in transform function for s390x.


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
