### PR TITLE
2142_dcount_parameter

### DIFF
--- a/.github/workflows/clibmouse_pr.yml
+++ b/.github/workflows/clibmouse_pr.yml
@@ -270,7 +270,7 @@ jobs:
         run: |
           docker ps --quiet | xargs --no-run-if-empty docker kill ||:
           docker ps --all --quiet | xargs --no-run-if-empty docker rm -f ||:
-          sudo rm -fr "$TEMP_PATH" "$CACHES_PATH"  
+          sudo rm -fr "$TEMP_PATH" "$CACHES_PATH"
   UnitTestsReleaseClang:
     needs: [BuilderBinRelease]
     runs-on: [self-hosted, fuzzer-unit-tester]

--- a/src/Parsers/Kusto/KQL_ReleaseNote.md
+++ b/src/Parsers/Kusto/KQL_ReleaseNote.md
@@ -1,6 +1,9 @@
 ## KQL implemented features  
 
 # January XX, 2023
+## Improvement
+- [dcount()](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/dcount-aggfunction) and [dcountif()](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/dcountif-aggfunction)
+   docunt and dcountif now accept the additional accuracy parameter which is the base-2 logarithm of the number of cells in  [HyperLogLog](https://en.wikipedia.org/wiki/HyperLogLog).
 ## Functions
 - [range()](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/rangefunction)  
 Difference from ADX:  
@@ -62,6 +65,7 @@ print range(endofday(datetime(2017-01-01 10:10:17)), endofday(datetime(2017-01-0
    Note: * is not currently a supported argument.
    ```
 - [take_anyif()](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/take-anyif-aggfunction)
+- [dcount() and dcountif()]
 ## Operator
 - [range](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/rangeoperator)  
    `range LastWeek from ago(7d) to now() step 1d`  

--- a/src/Parsers/Kusto/KustoFunctions/KQLAggregationFunctions.cpp
+++ b/src/Parsers/Kusto/KustoFunctions/KQLAggregationFunctions.cpp
@@ -67,8 +67,14 @@ bool DCount::convertImpl(String & out, IParser::Pos & pos)
         return false;
     ++pos;
     String value = getConvertedArgument(fn_name, pos);
-
-    out = "count ( DISTINCT " + value + " )";
+    if (pos->type == TokenType::Comma)
+    {
+        ++pos;
+        const auto accuracy = getConvertedArgument(fn_name, pos);
+        out = "count(DISTINCT " + value + " , " + accuracy + ")";
+    }
+    else
+        out = "count(DISTINCT " + value + ")";
     return true;
 }
 
@@ -82,7 +88,14 @@ bool DCountIf::convertImpl(String & out, IParser::Pos & pos)
     String value = getConvertedArgument(fn_name, pos);
     ++pos;
     String condition = getConvertedArgument(fn_name, pos);
-    out = "countIf ( DISTINCT " + value + " , " + condition + " )";
+    if (pos->type == TokenType::Comma)
+    {
+        ++pos;
+        const auto accuracy = getConvertedArgument(fn_name, pos);
+        out = "count(DISTINCT " + value + " , " + condition + " , " + accuracy + ")";
+    }
+    else
+        out = "countIf(DISTINCT " + value + " , " + condition + ")";
     return true;
 }
 
@@ -251,7 +264,7 @@ bool Percentilew::convertImpl(String & out, IParser::Pos & pos)
     String value = getConvertedArgument(fn_name, pos);
     trim(value);
 
-    out = "quantileExactWeighted(" + value + "/100)(" + bucket_column + "," + frequency_column +")";
+    out = "quantileExactWeighted(" + value + "/100)(" + bucket_column + "," + frequency_column + ")";
     return true;
 }
 
@@ -280,7 +293,7 @@ bool Percentiles::convertImpl(String & out, IParser::Pos & pos)
         else
             ++pos;
     }
-    out = expr + ")("+ column_name +")";
+    out = expr + ")(" + column_name + ")";
     return true;
 }
 

--- a/src/Parsers/tests/KQL/gtest_KQL_AggregateFunctions.cpp
+++ b/src/Parsers/tests/KQL/gtest_KQL_AggregateFunctions.cpp
@@ -97,5 +97,13 @@ INSTANTIATE_TEST_SUITE_P(ParserKQLQuery_Aggregate, ParserTest,
         {
             "Customers | summarize take_anyif(FirstName, LastName has 'Diaz'), dcount(FirstName)"
             "SELECT\n    anyIf(FirstName, hasTokenCaseInsensitive(LastName, 'Diaz')) AS take_anyif_FirstName,\n    countDistinct(FirstName) AS dcount_FirstName\nFROM Customers"
-        }
+	},
+	{
+            "Customers | summarize dcount(Education, 2)"
+            "SELECT countDistinct(Education, 2) AS dcount_Education\nFROM Customers"
+	},
+	{
+            "Customers | summarize dcountif(Education, Occupation=='Professional', 2)"
+            "SELECT countDistinct(Education, Occupation = 'Professional', 2) AS dcountif_Education\nFROM Customers"
+        }	
 })));

--- a/tests/queries/0_stateless/02366_kql_summarize.reference
+++ b/tests/queries/0_stateless/02366_kql_summarize.reference
@@ -19,7 +19,9 @@ Skilled Manual	151
 Professional	117
 Management abcd defg	33
 4
+4
 2
+6
 40	2
 30	4
 20	6

--- a/tests/queries/0_stateless/02366_kql_summarize.sql
+++ b/tests/queries/0_stateless/02366_kql_summarize.sql
@@ -58,7 +58,9 @@ Customers | summarize MyMin = minif(Age, Age<40) by Occupation;
 Customers | summarize MyAvg = avgif(Age, Age<40) by Occupation;
 Customers | summarize MySum = sumif(Age, Age<40) by Occupation;
 Customers | summarize dcount(Education);
+Customers | summarize dcount(Education, 2);
 Customers | summarize dcountif(Education, Occupation=='Professional');
+Customers | summarize dcountif(Education, Occupation=='Professional', 2);
 Customers | summarize count_ = count() by bin(Age, 10) | order by count_ asc;
 Customers | summarize job_count = count() by Occupation | where job_count > 0;
 Customers | summarize 'Edu Count'=count() by Education | sort by 'Edu Count' desc; -- { clientError 62 }


### PR DESCRIPTION
<!---
dcount and docuntif error out when passed the extra accuracy parameter.
-->
### Changelog category (leave one):

- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

[dcount()](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/dcount-aggfunction) and [dcountif()](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/dcountif-aggfunction)
   docunt and dcountif now accept the additional accuracy parameter which is the base-2 logarithm of the number of cells in  [HyperLogLog](https://en.wikipedia.org/wiki/HyperLogLog).

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
