### PR TITLE
Fix endian issue in snappy lib

### DIFF
--- a/contrib/snappy-cmake/CMakeLists.txt
+++ b/contrib/snappy-cmake/CMakeLists.txt
@@ -1,6 +1,10 @@
 set (SOURCE_DIR "${CMAKE_SOURCE_DIR}/contrib/snappy")
 
-set (SNAPPY_IS_BIG_ENDIAN 0)
+if (ARCH_S390X)
+    set (SNAPPY_IS_BIG_ENDIAN 1)
+else ()
+    set (SNAPPY_IS_BIG_ENDIAN 0)
+endif()
 
 set (HAVE_BYTESWAP_H 1)
 set (HAVE_SYS_MMAN_H 1)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
When running functional test `00900_long_parquet`, ClickHouse client crashes on s390x platform due to endian issue in snappy library.
The fix is to set SNAPPY_IS_BIG_ENDIAN as 1 when building snappy on s390x.

### Changelog category (leave one):
- Build Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed endian issue in snappy library for s390x platform.


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
