### PR TITLE
Kusto-phase3: fix mv-expand token index issue

### DIFF
--- a/src/Parsers/Kusto/ParserKQLMVExpand.cpp
+++ b/src/Parsers/Kusto/ParserKQLMVExpand.cpp
@@ -101,6 +101,7 @@ bool ParserKQLMVExpand::parseColumnArrayExprs(ColumnArrayExprs & column_array_ex
             ++pos;
             if (!close_bracket.ignore(pos, expected))
                 return false;
+            --pos;
         }
 
         if ((pos->type == TokenType::Comma && bracket_count == 0) || String(pos->begin, pos->end) == "limit" || pos->type == TokenType::Semicolon)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in official stable or prestable release)

fixed the token index of mv-expand operator


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
