### PR TITLE
Fix http xz compression issue for s390x

### DIFF
--- a/contrib/xz-cmake/CMakeLists.txt
+++ b/contrib/xz-cmake/CMakeLists.txt
@@ -94,6 +94,10 @@ if (ARCH_AMD64 OR ARCH_AARCH64)
     add_compile_definitions(TUKLIB_FAST_UNALIGNED_ACCESS=1)
 endif ()
 
+if (ARCH_S390X)
+    add_compile_definitions(WORDS_BIGENDIAN)
+endif ()
+
 find_package(Threads REQUIRED)
 
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
The xz library was not built with DWORDS_BIGENDIAN turned on, which causes the compression decoding failure.
The fix is to turn the flag on in CMake.

### Changelog category (leave one):

- Build Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed http xz compression issue for s390x.


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
