### PR TITLE
Fix halfMD5 and broken CityHash

### DIFF
--- a/src/Functions/FunctionsHashing.h
+++ b/src/Functions/FunctionsHashing.h
@@ -173,8 +173,11 @@ struct HalfMD5Impl
         MD5_Init(&ctx);
         MD5_Update(&ctx, reinterpret_cast<const unsigned char *>(begin), size);
         MD5_Final(buf.char_data, &ctx);
-
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+        return buf.uint64_data;        /// No need to flip bytes on big endian machines
+#else
         return Poco::ByteOrder::flipBytes(static_cast<Poco::UInt64>(buf.uint64_data));        /// Compatibility with existing code. Cast need for old poco AND macos where UInt64 != uint64_t
+#endif
     }
 
     static UInt64 combineHashes(UInt64 h1, UInt64 h2)
@@ -1026,22 +1029,9 @@ private:
                 if constexpr (Impl::use_int_hash_for_pods)
                 {
                     if constexpr (std::is_same_v<ToType, UInt64>)
-                    {
-                        UInt64 v = bit_cast<UInt64>(vec_from[i]);
-
-                        /// Consider using std::byteswap(c++23) in the future
-                        if constexpr (std::endian::native == std::endian::big)
-                            v = __builtin_bswap64(v);
-                        h = IntHash64Impl::apply(v);
-                    }
+                        h = IntHash64Impl::apply(bit_cast<UInt64>(vec_from[i]));
                     else
-                    {
-                        UInt32 v = bit_cast<UInt32>(vec_from[i]);
-                        if constexpr (std::endian::native == std::endian::big)
-                            v = __builtin_bswap32(v);
-                        h = IntHash32Impl::apply(v);
-                    }
-                }
+                        h = IntHash32Impl::apply(bit_cast<UInt32>(vec_from[i]));                }
                 else
                 {
                     if constexpr (std::is_same_v<Impl, JavaHashImpl>)
@@ -1070,20 +1060,10 @@ private:
             auto value = col_from_const->template getValue<FromType>();
             ToType hash;
             if constexpr (std::is_same_v<ToType, UInt64>)
-            {
-                UInt64 v = bit_cast<UInt64>(value);
-                if constexpr (std::endian::native == std::endian::big)
-                    v = __builtin_bswap64(v);
-                hash = IntHash64Impl::apply(v);
-            }
+                hash = IntHash64Impl::apply(bit_cast<UInt64>(value));
             else
-            {
-                UInt32 v = bit_cast<UInt32>(value);
-                if constexpr (std::endian::native == std::endian::big)
-                    v = __builtin_bswap32(v);
-                hash = IntHash32Impl::apply(v);
-            }
-
+                hash = IntHash32Impl::apply(bit_cast<UInt32>(value));
+      
             size_t size = vec_to.size();
             if constexpr (first)
             {


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
The PR addressed 2 issues for s390x：
1. halfMD5 byte order issue.
2. Rollback changes that cause broken cityhash in previous commit.

### Changelog category (leave one):

- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix halfMD5 and broken cityHash


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
