### PR TITLE
Kusto-phase3: fixed the bug core dump if query end with pipe

### DIFF
--- a/src/Parsers/Kusto/ParserKQLQuery.cpp
+++ b/src/Parsers/Kusto/ParserKQLQuery.cpp
@@ -90,7 +90,12 @@ bool ParserKQLBase::parseSQLQueryByString(ParserPtr && parser, String & query, A
 };
 
 bool ParserKQLBase::setSubQuerySource(
-    ASTPtr & select_query, ASTPtr & source, const bool dest_is_subquery, const bool src_is_subquery, const String alias, const int32_t table_index)
+    ASTPtr & select_query,
+    ASTPtr & source,
+    const bool dest_is_subquery,
+    const bool src_is_subquery,
+    const String alias,
+    const int32_t table_index)
 {
     ASTPtr table_expr;
     auto apply_alias = [&]()
@@ -292,7 +297,7 @@ String ParserKQLBase::getExprFromToken(Pos & pos)
             ++columms_start_pos;
         }
 
-        for (auto const  & token : tokens)
+        for (auto const & token : tokens)
             column_str = column_str.empty() ? token : column_str + " " + token;
 
         if (has_alias)
@@ -302,7 +307,8 @@ String ParserKQLBase::getExprFromToken(Pos & pos)
             {
                 String new_column_str;
                 if (start_pos->type != TokenType::BareWord)
-                    throw Exception(ErrorCodes::SYNTAX_ERROR, "{} is not a valid alias", std::string_view(start_pos->begin, start_pos->end));
+                    throw Exception(
+                        ErrorCodes::SYNTAX_ERROR, "{} is not a valid alias", std::string_view(start_pos->begin, start_pos->end));
 
                 if (function_name == "array_sort_asc" || function_name == "array_sort_desc")
                     new_column_str = std::format("{0}[1] AS {1}", column_str, String(start_pos->begin, start_pos->end));
@@ -419,10 +425,8 @@ std::unique_ptr<ParserKQLBase> ParserKQLQuery::getOperator(const std::string_vie
 
 bool ParserKQLQuery::getOperations(Pos & pos, Expected & expected, OperationsPos & operation_pos)
 {
-    String table_name(pos->begin, pos->end);
-
-    if (table_name == "print" || table_name == "range")
-        operation_pos.push_back(std::make_pair(table_name, pos));
+    if (String table_name(pos->begin, pos->end); table_name == "print" || table_name == "range")
+        operation_pos.emplace_back(table_name, pos);
     else
         operation_pos.emplace_back("table", pos);
 
@@ -439,6 +443,8 @@ bool ParserKQLQuery::getOperations(Pos & pos, Expected & expected, OperationsPos
         if (pos->type == TokenType::PipeMark && bracket_count == 0)
         {
             ++pos;
+            if (pos->isEnd())
+                return false;
             String kql_operator(pos->begin, pos->end);
 
             auto validate_kql_operator = [&]
@@ -446,8 +452,7 @@ bool ParserKQLQuery::getOperations(Pos & pos, Expected & expected, OperationsPos
                 if (kql_operator == "order" || kql_operator == "sort")
                 {
                     ++pos;
-                    ParserKeyword s_by("by");
-                    if (s_by.ignore(pos, expected))
+                    if (ParserKeyword("by").ignore(pos, expected))
                     {
                         kql_operator = "order by";
                         --pos;
@@ -457,16 +462,12 @@ bool ParserKQLQuery::getOperations(Pos & pos, Expected & expected, OperationsPos
                 {
                     auto op_pos_begin = pos;
                     ++pos;
-                    ParserToken s_dash(TokenType::Minus);
-                    if (s_dash.ignore(pos, expected))
-                    {
-                        String tmp_op(op_pos_begin->begin, pos->end);
-                        kql_operator = tmp_op;
-                    }
+                    if (ParserToken(TokenType::Minus).ignore(pos, expected))
+                        kql_operator = String(op_pos_begin->begin, pos->end);
                     else
                         --pos;
                 }
-                if (kql_parser.find(kql_operator) == kql_parser.end())
+                if (!kql_parser.contains(kql_operator))
                     return false;
                 return true;
             };
@@ -474,7 +475,11 @@ bool ParserKQLQuery::getOperations(Pos & pos, Expected & expected, OperationsPos
             if (!validate_kql_operator())
                 return false;
             ++pos;
-            operation_pos.push_back(std::make_pair(kql_operator, pos));
+
+            if ((kql_operator == "print" || kql_operator == "range") && !operation_pos.empty())
+                throw Exception(ErrorCodes::SYNTAX_ERROR, "{} must be the first operator in the query", kql_operator);
+
+            operation_pos.emplace_back(kql_operator, pos);
         }
         else
             ++pos;

--- a/src/Parsers/tests/KQL/gtest_KQL_General.cpp
+++ b/src/Parsers/tests/KQL/gtest_KQL_General.cpp
@@ -65,5 +65,17 @@ INSTANTIATE_TEST_SUITE_P(ParserKQLQuery_General, ParserTest,
         {
             "print lookup('dictionary_table', 'value', '100', 'default')",
             "SELECT dictGetOrDefault('dictionary_table', 'value', '100', 'default') AS print_0"
+        },
+        {
+            "T | print 1",
+            "throws AS print_0"
+        },
+        {
+            "T | range from 1 to 5 step 1",
+            "throws"
+        },
+        {
+            "T |",
+            "throws"
         }
 })));


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...
fixed the bug of core dump if query end with pipe, 
force print and range to be the first operator

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
