### PR TITLE
Correct type mapping for arrays

### DIFF
--- a/src/Parsers/Kusto/KQLDataType.cpp
+++ b/src/Parsers/Kusto/KQLDataType.cpp
@@ -15,7 +15,7 @@ namespace
 {
 const std::unordered_map<DB::TypeIndex, DB::KQLDataType> CLICKHOUSE_TO_KQL_TYPE{
     {DB::TypeIndex::AggregateFunction, DB::KQLDataType::Invalid},
-    {DB::TypeIndex::Array, DB::KQLDataType::Dynamic},
+    {DB::TypeIndex::Array, DB::KQLDataType::Array},
     {DB::TypeIndex::Date, DB::KQLDataType::DateTime},
     {DB::TypeIndex::Date32, DB::KQLDataType::DateTime},
     {DB::TypeIndex::DateTime, DB::KQLDataType::DateTime},
@@ -44,7 +44,7 @@ const std::unordered_map<DB::TypeIndex, DB::KQLDataType> CLICKHOUSE_TO_KQL_TYPE{
     {DB::TypeIndex::Nothing, DB::KQLDataType::Invalid},
     {DB::TypeIndex::Nullable, DB::KQLDataType::Invalid},
     {DB::TypeIndex::Object, DB::KQLDataType::Invalid},
-    {DB::TypeIndex::Set, DB::KQLDataType::Dynamic},
+    {DB::TypeIndex::Set, DB::KQLDataType::Dictionary},
     {DB::TypeIndex::String, DB::KQLDataType::String},
     {DB::TypeIndex::Tuple, DB::KQLDataType::Invalid},
     {DB::TypeIndex::UInt8, DB::KQLDataType::Int},

--- a/src/Parsers/Kusto/KQLDataType.h
+++ b/src/Parsers/Kusto/KQLDataType.h
@@ -8,10 +8,11 @@ namespace DB
 {
 enum class KQLDataType
 {
+    Array,
     Bool,
     DateTime,
     Decimal,
-    Dynamic,
+    Dictionary,
     Guid,
     Int,
     Invalid,

--- a/tests/queries/0_stateless/02366_kql_func_general.reference
+++ b/tests/queries/0_stateless/02366_kql_func_general.reference
@@ -40,5 +40,5 @@ default
 -- gettype
 string
 int
-dynamic
+array
 datetime


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix KQL type mapping used by gettype and getschema for arrays