### PR TITLE
Kusto-phase3 : enable range to be inside other function for a nested call

### DIFF
--- a/src/Parsers/Kusto/ParserKQLQuery.cpp
+++ b/src/Parsers/Kusto/ParserKQLQuery.cpp
@@ -22,18 +22,18 @@
 #include <Parsers/Kusto/ParserKQLOperators.h>
 #include <Parsers/Kusto/ParserKQLPrint.h>
 #include <Parsers/Kusto/ParserKQLProject.h>
+#include <Parsers/Kusto/ParserKQLProjectAway.h>
 #include <Parsers/Kusto/ParserKQLQuery.h>
+#include <Parsers/Kusto/ParserKQLRange.h>
 #include <Parsers/Kusto/ParserKQLSort.h>
 #include <Parsers/Kusto/ParserKQLStatement.h>
 #include <Parsers/Kusto/ParserKQLSummarize.h>
 #include <Parsers/Kusto/ParserKQLTable.h>
 #include <Parsers/Kusto/ParserKQLTop.h>
 #include <Parsers/Kusto/ParserKQLTopHitter.h>
+#include <Parsers/Kusto/ParserKQLTopNested.h>
 #include <Parsers/ParserSelectWithUnionQuery.h>
 #include <Parsers/ParserTablesInSelectQuery.h>
-#include <Parsers/Kusto/ParserKQLTopNested.h>
-#include <Parsers/Kusto/ParserKQLRange.h>
-#include <Parsers/Kusto/ParserKQLProjectAway.h>
 #include <format>
 
 namespace DB
@@ -258,12 +258,14 @@ String ParserKQLBase::getExprFromToken(Pos & pos)
         if (String(it_pos->begin, it_pos->end) == "=")
             throw Exception(ErrorCodes::SYNTAX_ERROR, "Invalid equal symbol (=)");
 
+        BracketCount bracket_count;
         while (it_pos < end_pos)
         {
+            bracket_count.count(it_pos);
             if (String(it_pos->begin, it_pos->end) == "=")
             {
                 ++it_pos;
-                if (String(it_pos->begin, it_pos->end) != "~")
+                if (String(it_pos->begin, it_pos->end) != "~" && bracket_count.isZero())
                 {
                     if (has_alias)
                         throw Exception(ErrorCodes::SYNTAX_ERROR, "Invalid equal symbol (=)");

--- a/src/Parsers/Kusto/ParserKQLQuery.h
+++ b/src/Parsers/Kusto/ParserKQLQuery.h
@@ -13,10 +13,16 @@ public:
     static String getExprFromToken(Pos & pos);
     static String getExprFromToken(const String & text, const uint32_t max_depth);
     static String getExprFromPipe(Pos & pos);
-    static bool setSubQuerySource(ASTPtr & select_query, ASTPtr & source, const bool dest_is_subquery, const bool src_is_subquery, const String alias = "", const int32_t table_index = 0);
+    static bool setSubQuerySource(
+        ASTPtr & select_query,
+        ASTPtr & source,
+        const bool dest_is_subquery,
+        const bool src_is_subquery,
+        const String alias = "",
+        const int32_t table_index = 0);
     static bool parseSQLQueryByString(ParserPtr && parser, String & query, ASTPtr & select_node, int32_t max_depth);
     bool parseByString(const String expr, ASTPtr & node, const uint32_t max_depth);
-    virtual bool updatePipeLine (OperationsPos & /*operations*/, String & /*query*/) {return false;}
+    virtual bool updatePipeLine(OperationsPos & /*operations*/, String & /*query*/) { return false; }
 };
 
 class ParserKQLQuery : public IParserBase
@@ -31,6 +37,7 @@ public:
         int8_t backspace_steps; // how many steps to last token of previous pipe
     };
     static bool getOperations(Pos & pos, Expected & expected, OperationsPos & operation_pos);
+
 protected:
     static std::unique_ptr<ParserKQLBase> getOperator(std::string_view op_name);
     static bool pre_process(String & source, Pos & pos);
@@ -49,10 +56,32 @@ protected:
 class ParserSimpleCHSubquery : public ParserKQLBase
 {
 public:
-    ParserSimpleCHSubquery(ASTPtr parent_select_node_ = nullptr) {parent_select_node = parent_select_node_;}
+    ParserSimpleCHSubquery(ASTPtr parent_select_node_ = nullptr) { parent_select_node = parent_select_node_; }
+
 protected:
     const char * getName() const override { return "Simple ClickHouse subquery"; }
     bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
     ASTPtr parent_select_node;
+};
+
+class BracketCount
+{
+public:
+    void count(IParser::Pos & pos)
+    {
+        if (pos->type == TokenType::OpeningRoundBracket)
+            ++round_bracket_count;
+        if (pos->type == TokenType::ClosingRoundBracket)
+            --round_bracket_count;
+        if (pos->type == TokenType::OpeningSquareBracket)
+            ++square_bracket_count;
+        if (pos->type == TokenType::ClosingSquareBracket)
+            --square_bracket_count;
+    }
+    bool isZero() const { return round_bracket_count == 0 && square_bracket_count == 0; }
+
+private:
+    int16_t round_bracket_count = 0;
+    int16_t square_bracket_count = 0;
 };
 }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
enable range to be inside other function for a nested call


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
