### PR TITLE
Fix byte order of partition id for s390x

### DIFF
--- a/src/Storages/MergeTree/MergeTreePartition.cpp
+++ b/src/Storages/MergeTree/MergeTreePartition.cpp
@@ -261,8 +261,11 @@ String MergeTreePartition::getID(const Block & partition_key_sample) const
     hash.get128(hash_data);
     result.resize(32);
     for (size_t i = 0; i < 16; ++i)
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+        writeHexByteLowercase(hash_data[16 - 1 - i], &result[2 * i]);
+#else
         writeHexByteLowercase(hash_data[i], &result[2 * i]);
-
+#endif
     return result;
 }
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
On s390x, the partition ID has reversed byte order compared to those on little-endian machines. The fix is to reverse the byte order so that partition IDs keep the same on both little-endian and big-endian machines.
### Changelog category (leave one):
Testing Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed the byte order issue of partition IDs on s390x.


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
