### PR TITLE
Fix decimal-256 text output issue on s390x

### DIFF
--- a/base/base/wide_integer_impl.h
+++ b/base/base/wide_integer_impl.h
@@ -732,9 +732,10 @@ public:
             if (std::numeric_limits<T>::is_signed && (is_negative(lhs) != is_negative(rhs)))
                 return is_negative(rhs);
 
+            integer<Bits, Signed> t = rhs;
             for (unsigned i = 0; i < item_count; ++i)
             {
-                base_type rhs_item = get_item(rhs, big(i));
+                base_type rhs_item = get_item(t, big(i));
 
                 if (lhs.items[big(i)] != rhs_item)
                     return lhs.items[big(i)] > rhs_item;
@@ -757,9 +758,10 @@ public:
             if (std::numeric_limits<T>::is_signed && (is_negative(lhs) != is_negative(rhs)))
                 return is_negative(lhs);
 
+            integer<Bits, Signed> t = rhs;
             for (unsigned i = 0; i < item_count; ++i)
             {
-                base_type rhs_item = get_item(rhs, big(i));
+                base_type rhs_item = get_item(t, big(i));
 
                 if (lhs.items[big(i)] != rhs_item)
                     return lhs.items[big(i)] < rhs_item;
@@ -779,9 +781,10 @@ public:
     {
         if constexpr (should_keep_size<T>())
         {
+            integer<Bits, Signed> t = rhs;
             for (unsigned i = 0; i < item_count; ++i)
             {
-                base_type rhs_item = get_item(rhs, any(i));
+                base_type rhs_item = get_item(t, any(i));
 
                 if (lhs.items[any(i)] != rhs_item)
                     return false;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
On 390x, ClickHouse client writes incorrect text output of decimal256 values. For example:

```
CREATE TABLE t(d Decimal256(40)) ENGINE=Memory; 
insert into t values(4.5);
select * from t;
```

it returns `45.0236046863106861511512755495955245039616`

The reason is that when writeDecimalFractional() in WriteHelpers.h is called, the 256 bit wide integer which represents the decimal is compared with `std::numeric_limits<UInt128>::max()` and returns true instead of false.

During the comparison( function operator_less() in base/base/wide_integer_impl.h), decimal256's item_count is 4 and the UInt128::max()'s item_count is 2 and comparison will fail on big-endian machines like s390x(it works on little-endian machine since get_item returns 0 when index is out of range). 

For example:

A decimal256's items are as following:

```
[0] = 0, [1] = 11, [2] = 13926249686295819025, [3] = 9049237982317379584
```

UInt128::max's items are as following:
```
[0] = 18446744073709551615, [1] = 18446744073709551615
```
which should be the following during comparison:
```
[0] = 0, [1] = 0, [2]=18446744073709551615, [3] = 18446744073709551615
```

The fix is to convert `"rhs"` to a 256 bit wide integer before comparison.

### Changelog category (leave one):
- Build Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed decimal-256 text output issue on s390x.


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
