### PR TITLE
Fix partition hash issue

### DIFF
--- a/src/Storages/MergeTree/MergeTreePartition.cpp
+++ b/src/Storages/MergeTree/MergeTreePartition.cpp
@@ -84,7 +84,15 @@ namespace
         }
         void operator() (const UUID & x) const
         {
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+            auto tmp_x = x.toUnderType();
+            char *start = reinterpret_cast<char *>(&tmp_x);
+            char *end = start + sizeof(tmp_x);
+            std::reverse(start, end);
+            operator()(tmp_x);
+#else
             operator()(x.toUnderType());
+#endif		
         }
         void operator() (const IPv4 & x) const
         {


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
On s390x, the following functional tests fail:
```
01891_partition_hash
01891_partition_hash_no_long_int
01891_partition_by_uuid
```
The reason is that the UUID data is directly used before hashing when creating partition IDs and it generate different hash results compared with those in little-endian machines.
The fix is to reverse the byte order of UUID before hashing on s390x.

### Changelog category (leave one):
- Build Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed hashing issue in creating partition IDs for s390x.


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
