### PR TITLE
Always store checksums in little-endian

### DIFF
--- a/src/Compression/CompressedReadBufferBase.cpp
+++ b/src/Compression/CompressedReadBufferBase.cpp
@@ -1,4 +1,5 @@
 #include "CompressedReadBufferBase.h"
+#include "Utilities.h"
 
 #include <bit>
 #include <cstring>
@@ -40,7 +41,7 @@ using Checksum = CityHash_v1_0_2::uint128;
 /// Validate checksum of data, and if it mismatches, find out possible reason and throw exception.
 static void validateChecksum(char * data, size_t size, const Checksum expected_checksum)
 {
-    auto calculated_checksum = CityHash_v1_0_2::CityHash128(data, size);
+    const auto calculated_checksum = CalculateCityHash128InLittleEndian({data, size});
     if (expected_checksum == calculated_checksum)
         return;
 
@@ -81,7 +82,7 @@ static void validateChecksum(char * data, size_t size, const Checksum expected_c
         {
             flip_bit(tmp_data, bit_pos);
 
-            auto checksum_of_data_with_flipped_bit = CityHash_v1_0_2::CityHash128(tmp_data, size);
+            const auto checksum_of_data_with_flipped_bit = CalculateCityHash128InLittleEndian({tmp_data, size});
             if (expected_checksum == checksum_of_data_with_flipped_bit)
             {
                 message << ". The mismatch is caused by single bit flip in data block at byte " << (bit_pos / 8) << ", bit " << (bit_pos % 8) << ". "

--- a/src/Compression/Utilities.cpp
+++ b/src/Compression/Utilities.cpp
@@ -1,0 +1,15 @@
+#include "Utilities.h"
+
+namespace DB
+{
+CityHash_v1_0_2::uint128 CalculateCityHash128InLittleEndian(const std::span<char> buffer)
+{
+    const auto hash = CityHash_v1_0_2::CityHash128(buffer.data(), buffer.size());
+
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    return {__builtin_bswap64(hash.first), __builtin_bswap64(hash.second)};
+#else
+    return hash;
+#endif
+}
+}

--- a/src/Compression/Utilities.h
+++ b/src/Compression/Utilities.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <city.h>
+
+#include <span>
+
+namespace DB
+{
+CityHash_v1_0_2::uint128 CalculateCityHash128InLittleEndian(std::span<char> buffer);
+}


### PR DESCRIPTION
The modification ensures that `CompressedWriteBuffer` and `CompressedReadBufferBase` both treat checksums as little-endian in order to provide interoperability between platforms of different endianness. It's a breaking change for big-endian platforms, but it shouldn't have any impact on little-endian ones.

This fixes functional test suite `tests/queries/0_stateless/01601_proxy_protocol.sh`.

Examples of use-cases:
* client and server are running on platforms of different endianness,
* working directory of a server is transferred among platforms of different endianness.

### Changelog category (leave one):
- Backward Incompatible Change
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Implement interoperability between platforms for `CompressedWriteBuffer` and `CompressedReadBufferBase` by always using little-endian to store checksums.