### PR TITLE
Fix UUID sort order issue on s390x

### DIFF
--- a/src/Columns/ColumnVector.h
+++ b/src/Columns/ColumnVector.h
@@ -46,7 +46,22 @@ struct CompareHelper
       */
     static constexpr int compare(T a, U b, int /*nan_direction_hint*/)
     {
-        return a > b ? 1 : (a < b ? -1 : 0);
+        if constexpr (std::endian::native == std::endian::big && std::same_as<T, UUID> && std::same_as<U, UUID>)
+        {
+            UUID tmp_a = a;
+            char *start = reinterpret_cast<char *>(&tmp_a);
+            char *end = start + sizeof(tmp_a);
+            std::reverse(start, end);
+
+            UUID tmp_b = b;
+            start = reinterpret_cast<char *>(&tmp_b);
+            end = start + sizeof(tmp_b);
+            std::reverse(start, end);
+
+            return tmp_a > tmp_b ? 1 : (tmp_a < tmp_b ? -1 : 0);
+        }
+        else
+            return a > b ? 1 : (a < b ? -1 : 0);
     }
 };
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
On big-endian machine like s390x, when SQL SELECT is ordered by UUID, the ordered result will be different from the result on little-endian machines. This fails the functional tests like 01533_distinct_nullable_uuid.

The fix is to reverse the byte orders of UUIDs and compare using the reverted UUIDs so that it generates same results as those in little-endian machines.


### Changelog category (leave one):
- Build Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed UUID sort order issue in SELECT statement on s390x.


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
