### PR TITLE
Fix the code to use the RapidJSONParser in case of big-endian system

### DIFF
--- a/src/DataTypes/Serializations/SerializationObject.cpp
+++ b/src/DataTypes/Serializations/SerializationObject.cpp
@@ -541,7 +541,7 @@ SerializationPtr getObjectSerialization(const String & schema_format)
 {
     if (schema_format == "json")
     {
-#if USE_SIMDJSON
+#if USE_SIMDJSON && __BYTE_ORDER__ != __ORDER_BIG_ENDIAN__
         return std::make_shared<SerializationObject<JSONDataParser<SimdJSONParser>>>();
 #elif USE_RAPIDJSON
         return std::make_shared<SerializationObject<JSONDataParser<RapidJSONParser>>>();


### PR DESCRIPTION
By default, ClickHouse use the SimdJSONParser to parse the JSON data. In case of big-endian s390x, the library has an issue in parsing the JSON float value. 

Modify the code to use the RapidJSONParser in case of big-endian system.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Use the RapidJSONParser library to parse the JSON float values in case of s390x.


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
