### PR TITLE
Fix metadata test s390x

### DIFF
--- a/src/DataTypes/Serializations/SerializationObject.cpp
+++ b/src/DataTypes/Serializations/SerializationObject.cpp
@@ -541,7 +541,7 @@ SerializationPtr getObjectSerialization(const String & schema_format)
 {
     if (schema_format == "json")
     {
-#if USE_SIMDJSON
+#if USE_SIMDJSON && __BYTE_ORDER__ != __ORDER_BIG_ENDIAN__
         return std::make_shared<SerializationObject<JSONDataParser<SimdJSONParser>>>();
 #elif USE_RAPIDJSON
         return std::make_shared<SerializationObject<JSONDataParser<RapidJSONParser>>>();

--- a/tests/queries/0_stateless/01193_metadata_loading.sh
+++ b/tests/queries/0_stateless/01193_metadata_loading.sh
@@ -13,6 +13,10 @@ threads=10
 count_multiplier=1
 max_time_ms=1000
 
+if [[ $(uname -a | grep s390x) ]]; then
+   max_time_ms=1500
+fi
+
 debug_or_sanitizer_build=$($CLICKHOUSE_CLIENT -q "WITH ((SELECT value FROM system.build_options WHERE name='BUILD_TYPE') AS build, (SELECT value FROM system.build_options WHERE name='CXX_FLAGS') as flags) SELECT build='Debug' OR flags LIKE '%fsanitize%' OR hasThreadFuzzer()")
 
 if [[ debug_or_sanitizer_build -eq 1 ]]; then tables=100; count_multiplier=10; max_time_ms=1500; fi


### PR DESCRIPTION
Fix the 01193_metadata_loading test to match the query execution time specific to s390x.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix the 01193_metadata_loading test to match the query execution time specific to s390x.


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
