### PR TITLE
Fix jemalloc test on s390x

### DIFF
--- a/tests/queries/0_stateless/01502_jemalloc_percpu_arena.sh
+++ b/tests/queries/0_stateless/01502_jemalloc_percpu_arena.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-tsan, no-asan, no-msan, no-ubsan, no-fasttest
+# Tags: no-tsan, no-asan, no-msan, no-ubsan, no-fasttest, no-cpu-s390x
 #       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 # NOTE: jemalloc is disabled under sanitizers
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
Since s390x doesn't support functional test `01502_jemalloc_percpu_arena` fails on s390x.
The fix is to skip this test for s390x.

### Changelog category (leave one):
- Testing Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Disabled 01502_jemalloc_percpu_arena functional test for s390x.


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
