### PR TITLE
Optimization fix for T64 codec Libraries

### DIFF
--- a/src/Compression/CompressionCodecT64.cpp
+++ b/src/Compression/CompressionCodecT64.cpp
@@ -378,6 +378,13 @@ void transpose(const T * src, char * dst, UInt32 num_bits, UInt32 tail = 64)
 
 /// UInt64[N] transposed matrix -> UIntX[64]
 template <typename T, bool full = false>
+#if defined(__s390x__)
+
+/* Compiler Bug for S390x :- https://github.com/llvm/llvm-project/issues/62572
+ * Please remove this after the fix is backported
+ */
+        __attribute__((noinline))
+#endif
 void reverseTranspose(const char * src, T * buf, UInt32 num_bits, UInt32 tail = 64)
 {
     UInt64 matrix[64] = {};


### PR DESCRIPTION
The test's relating to the T64 Codec libraries were failing on the  S390x in the Release Build. This is due to a bug found with the clang compiler for s390x  ([Link](https://github.com/llvm/llvm-project/issues/62572)). This is a temporary fix and should be removed once the compiler fix is back ported to the previous versions.

### Changelog category (leave one):
* Build Improvement 
> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
