### PR TITLE
Fix default hash issue for s390x

### DIFF
--- a/src/Common/HashTable/Hash.h
+++ b/src/Common/HashTable/Hash.h
@@ -251,7 +251,10 @@ requires (sizeof(T) <= sizeof(UInt64))
 inline size_t DefaultHash64(T key)
 {
     DB::UInt64 out {0};
-    std::memcpy(&out, &key, sizeof(T));
+    if constexpr (std::endian::native == std::endian::little)
+        std::memcpy(&out, &key, sizeof(T));
+    else
+        std::memcpy(reinterpret_cast<char*>(&out) + sizeof(DB::UInt64) - sizeof(T), &key, sizeof(T));
     return intHash64(out);
 }
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
Functional test `00915_simple_aggregate_function` failed on s390x because LittleEndian Machine and BigEndian Machine generates different sets. For example,


```
create table simple (
    id UInt64,
    uniq_arr SimpleAggregateFunction(groupUniqArrayArray, Array(Int32))
) engine=AggregatingMergeTree order by id;

insert into simple values(1, [1,2]);

insert into simple values(1, [2,3,4]);

optimize table simple final;

select * from simple;

```

on s390x:
```
┌─id─┬─uniq_arr──┐
│  1 │ [2,3,1,4] │
└────┴───────────┘
```

on x86:

```
┌─id─┬─uniq_arr──┐
│  1 │ [4,2,1,3] │
└────┴───────────┘
```
The order of elements are different because there is a bug in  src/Common/HashTable/Hash.h:DefaultHash64(), which generate wrong hash values for hashing non-64 bit integers on s390x. This will cause HashSetWithStackMemory used in AggregateFunctionGroupUniqArrayData having wrong element order in the set on BigEndian machines like s390x.

The PR is to fix DefaultHash64 by providing correct offset to memcpy() on s390x.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed DefaultHash64 for non-64 bit integers on s390x.


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
