### PR TITLE
Fix native protocol endian issue in z build

### DIFF
--- a/src/DataTypes/Serializations/SerializationArray.cpp
+++ b/src/DataTypes/Serializations/SerializationArray.cpp
@@ -129,7 +129,7 @@ namespace
         for (size_t i = offset; i < end; ++i)
         {
             ColumnArray::Offset current_offset = offset_values[i];
-            writeIntBinary(current_offset - prev_offset, ostr);
+            writePODBinaryLittleEndian(current_offset - prev_offset, ostr);
             prev_offset = current_offset;
         }
     }
@@ -145,7 +145,7 @@ namespace
         while (i < initial_size + limit && !istr.eof())
         {
             ColumnArray::Offset current_size = 0;
-            readIntBinary(current_size, istr);
+            readPODBinaryLittleEndian(current_size, istr);
 
             if (unlikely(current_size > MAX_ARRAY_SIZE))
                 throw Exception(ErrorCodes::TOO_LARGE_ARRAY_SIZE, "Array size is too large: {}", current_size);

--- a/src/DataTypes/Serializations/SerializationDecimalBase.cpp
+++ b/src/DataTypes/Serializations/SerializationDecimalBase.cpp
@@ -10,19 +10,18 @@
 
 namespace DB
 {
-
 template <typename T>
 void SerializationDecimalBase<T>::serializeBinary(const Field & field, WriteBuffer & ostr, const FormatSettings &) const
 {
     FieldType x = field.get<DecimalField<T>>();
-    writeBinary(x, ostr);
+    writePODBinaryLittleEndian(x, ostr);
 }
 
 template <typename T>
 void SerializationDecimalBase<T>::serializeBinary(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings &) const
 {
     const FieldType & x = assert_cast<const ColumnType &>(column).getElement(row_num);
-    writeBinary(x, ostr);
+    writePODBinaryLittleEndian(x, ostr);
 }
 
 template <typename T>
@@ -34,15 +33,26 @@ void SerializationDecimalBase<T>::serializeBinaryBulk(const IColumn & column, Wr
 
     if (limit == 0 || offset + limit > size)
         limit = size - offset;
-
-    ostr.write(reinterpret_cast<const char *>(&x[offset]), sizeof(FieldType) * limit);
+    if constexpr (std::endian::native == std::endian::big && sizeof(T) >= 2)
+    {
+        for (size_t i = 0; i < limit; i++)
+        {
+            auto tmp(x[offset+i]);
+            char *start = reinterpret_cast<char*>(&tmp);
+            char *end = start + sizeof(FieldType);
+            std::reverse(start, end);
+            ostr.write(reinterpret_cast<const char *>(&tmp), sizeof(FieldType));
+        }
+    }
+    else
+        ostr.write(reinterpret_cast<const char *>(&x[offset]), sizeof(FieldType) * limit);
 }
 
 template <typename T>
 void SerializationDecimalBase<T>::deserializeBinary(Field & field, ReadBuffer & istr, const FormatSettings &) const
 {
     typename FieldType::NativeType x;
-    readBinary(x, istr);
+    readPODBinaryLittleEndian(x, istr);
     field = DecimalField(T(x), this->scale);
 }
 
@@ -50,7 +60,7 @@ template <typename T>
 void SerializationDecimalBase<T>::deserializeBinary(IColumn & column, ReadBuffer & istr, const FormatSettings &) const
 {
     typename FieldType::NativeType x;
-    readBinary(x, istr);
+    readPODBinaryLittleEndian(x, istr);
     assert_cast<ColumnType &>(column).getData().push_back(FieldType(x));
 }
 
@@ -61,6 +71,16 @@ void SerializationDecimalBase<T>::deserializeBinaryBulk(IColumn & column, ReadBu
     size_t initial_size = x.size();
     x.resize(initial_size + limit);
     size_t size = istr.readBig(reinterpret_cast<char*>(&x[initial_size]), sizeof(FieldType) * limit);
+    if constexpr (std::endian::native == std::endian::big && sizeof(T) >= 2)
+    {
+        for (size_t i = 0; i < limit; i++)
+        {
+            char *start = reinterpret_cast<char*>(&x[initial_size + i]);
+            char *end = start + sizeof(FieldType);
+            std::reverse(start, end);            
+        }
+    }
+
     x.resize(initial_size + size / sizeof(FieldType));
 }
 

--- a/src/DataTypes/Serializations/SerializationLowCardinality.cpp
+++ b/src/DataTypes/Serializations/SerializationLowCardinality.cpp
@@ -132,13 +132,13 @@ struct IndexesSerializationType
             val |= NeedGlobalDictionaryBit;
         if (need_update_dictionary)
             val |= NeedUpdateDictionary;
-        writeIntBinary(val, buffer);
+        writePODBinaryLittleEndian(val, buffer);
     }
 
     void deserialize(ReadBuffer & buffer, const ISerialization::DeserializeBinaryBulkSettings & settings)
     {
         SerializationType val;
-        readIntBinary(val, buffer);
+        readPODBinaryLittleEndian(val, buffer);
 
         checkType(val);
         has_additional_keys = (val & HasAdditionalKeysBit) != 0;
@@ -235,7 +235,7 @@ void SerializationLowCardinality::serializeBinaryBulkStatePrefix(
     /// Write version and create SerializeBinaryBulkState.
     UInt64 key_version = KeysSerializationVersion::SharedDictionariesWithAdditionalKeys;
 
-    writeIntBinary(key_version, *stream);
+    writePODBinaryLittleEndian(key_version, *stream);
 
     state = std::make_shared<SerializeStateLowCardinality>(key_version);
 }
@@ -259,7 +259,7 @@ void SerializationLowCardinality::serializeBinaryBulkStateSuffix(
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Got empty stream in SerializationLowCardinality::serializeBinaryBulkStateSuffix");
 
         UInt64 num_keys = nested_column->size();
-        writeIntBinary(num_keys, *stream);
+        writePODBinaryLittleEndian(num_keys, *stream);
         dict_inner_serialization->serializeBinaryBulk(*nested_column, *stream, 0, num_keys);
         low_cardinality_state->shared_dictionary = nullptr;
     }
@@ -277,7 +277,7 @@ void SerializationLowCardinality::deserializeBinaryBulkStatePrefix(
         return;
 
     UInt64 keys_version;
-    readIntBinary(keys_version, *stream);
+    readPODBinaryLittleEndian(keys_version, *stream);
 
     state = std::make_shared<DeserializeStateLowCardinality>(keys_version);
 }
@@ -535,7 +535,7 @@ void SerializationLowCardinality::serializeBinaryBulkWithMultipleStreams(
     {
         const auto & nested_column = global_dictionary->getNestedNotNullableColumn();
         UInt64 num_keys = nested_column->size();
-        writeIntBinary(num_keys, *keys_stream);
+        writePODBinaryLittleEndian(num_keys, *keys_stream);
         dict_inner_serialization->serializeBinaryBulk(*nested_column, *keys_stream, 0, num_keys);
         low_cardinality_state->shared_dictionary = nullptr;
     }
@@ -543,12 +543,12 @@ void SerializationLowCardinality::serializeBinaryBulkWithMultipleStreams(
     if (need_additional_keys)
     {
         UInt64 num_keys = keys->size();
-        writeIntBinary(num_keys, *indexes_stream);
+        writePODBinaryLittleEndian(num_keys, *indexes_stream);
         dict_inner_serialization->serializeBinaryBulk(*keys, *indexes_stream, 0, num_keys);
     }
 
     UInt64 num_rows = positions->size();
-    writeIntBinary(num_rows, *indexes_stream);
+    writePODBinaryLittleEndian(num_rows, *indexes_stream);
     auto index_serialization = index_version.getDataType()->getDefaultSerialization();
     index_serialization->serializeBinaryBulk(*positions, *indexes_stream, 0, num_rows);
 }
@@ -584,7 +584,7 @@ void SerializationLowCardinality::deserializeBinaryBulkWithMultipleStreams(
     auto read_dictionary = [this, low_cardinality_state, keys_stream]()
     {
         UInt64 num_keys;
-        readIntBinary(num_keys, *keys_stream);
+        readPODBinaryLittleEndian(num_keys, *keys_stream);
 
         auto keys_type = removeNullable(dictionary_type);
         auto global_dict_keys = keys_type->createColumn();
@@ -597,7 +597,7 @@ void SerializationLowCardinality::deserializeBinaryBulkWithMultipleStreams(
     auto read_additional_keys = [this, low_cardinality_state, indexes_stream]()
     {
         UInt64 num_keys;
-        readIntBinary(num_keys, *indexes_stream);
+        readPODBinaryLittleEndian(num_keys, *indexes_stream);
 
         auto keys_type = removeNullable(dictionary_type);
         auto additional_keys = keys_type->createColumn();
@@ -703,7 +703,7 @@ void SerializationLowCardinality::deserializeBinaryBulkWithMultipleStreams(
             else
                 low_cardinality_state->additional_keys = nullptr;
 
-            readIntBinary(low_cardinality_state->num_pending_rows, *indexes_stream);
+            readPODBinaryLittleEndian(low_cardinality_state->num_pending_rows, *indexes_stream);
         }
 
         size_t num_rows_to_read = std::min<UInt64>(limit, low_cardinality_state->num_pending_rows);

--- a/src/DataTypes/Serializations/SerializationNumber.cpp
+++ b/src/DataTypes/Serializations/SerializationNumber.cpp
@@ -106,28 +106,28 @@ void SerializationNumber<T>::serializeBinary(const Field & field, WriteBuffer & 
 {
     /// ColumnVector<T>::ValueType is a narrower type. For example, UInt8, when the Field type is UInt64
     typename ColumnVector<T>::ValueType x = static_cast<typename ColumnVector<T>::ValueType>(field.get<FieldType>());
-    writeBinary(x, ostr);
+    writePODBinaryLittleEndian(x, ostr);
 }
 
 template <typename T>
 void SerializationNumber<T>::deserializeBinary(Field & field, ReadBuffer & istr, const FormatSettings &) const
 {
     typename ColumnVector<T>::ValueType x;
-    readBinary(x, istr);
+    readPODBinaryLittleEndian(x, istr);
     field = NearestFieldType<FieldType>(x);
 }
 
 template <typename T>
 void SerializationNumber<T>::serializeBinary(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings &) const
 {
-    writeBinary(assert_cast<const ColumnVector<T> &>(column).getData()[row_num], ostr);
+    writePODBinaryLittleEndian(assert_cast<const ColumnVector<T> &>(column).getData()[row_num], ostr);
 }
 
 template <typename T>
 void SerializationNumber<T>::deserializeBinary(IColumn & column, ReadBuffer & istr, const FormatSettings &) const
 {
     typename ColumnVector<T>::ValueType x;
-    readBinary(x, istr);
+    readPODBinaryLittleEndian(x, istr);
     assert_cast<ColumnVector<T> &>(column).getData().push_back(x);
 }
 
@@ -142,7 +142,21 @@ void SerializationNumber<T>::serializeBinaryBulk(const IColumn & column, WriteBu
         limit = size - offset;
 
     if (limit)
-        ostr.write(reinterpret_cast<const char *>(&x[offset]), sizeof(typename ColumnVector<T>::ValueType) * limit);
+    {
+        if constexpr (std::endian::native == std::endian::big && sizeof(T) >= 2)
+        {
+            for (size_t i = 0; i < limit; i++)
+            {
+                auto tmp(x[offset+i]);
+                char *start = reinterpret_cast<char*>(&tmp);
+                char *end = start + sizeof(typename ColumnVector<T>::ValueType);
+                std::reverse(start, end);
+                ostr.write(reinterpret_cast<const char *>(&tmp), sizeof(typename ColumnVector<T>::ValueType));
+            }
+        }
+        else
+            ostr.write(reinterpret_cast<const char *>(&x[offset]), sizeof(typename ColumnVector<T>::ValueType) * limit);
+    }
 }
 
 template <typename T>
@@ -152,6 +166,15 @@ void SerializationNumber<T>::deserializeBinaryBulk(IColumn & column, ReadBuffer 
     size_t initial_size = x.size();
     x.resize(initial_size + limit);
     size_t size = istr.readBig(reinterpret_cast<char*>(&x[initial_size]), sizeof(typename ColumnVector<T>::ValueType) * limit);
+    if constexpr (std::endian::native == std::endian::big && sizeof(T) >= 2)
+    {
+        for (size_t i = 0; i < limit; i++)
+        {
+            char *start = reinterpret_cast<char*>(&x[initial_size + i]);
+            char *end = start + sizeof(typename ColumnVector<T>::ValueType);
+            std::reverse(start, end);            
+        }
+    }
     x.resize(initial_size + size / sizeof(typename ColumnVector<T>::ValueType));
 }
 

--- a/src/IO/ReadHelpers.cpp
+++ b/src/IO/ReadHelpers.cpp
@@ -1353,7 +1353,7 @@ Exception readException(ReadBuffer & buf, const String & additional_message, boo
     String stack_trace;
     bool has_nested = false;    /// Obsolete
 
-    readBinary(code, buf);
+    readBinaryLittleEndian(code, buf);
     readBinary(name, buf);
     readBinary(message, buf);
     readBinary(stack_trace, buf);

--- a/src/IO/ReadHelpers.h
+++ b/src/IO/ReadHelpers.h
@@ -105,12 +105,22 @@ inline void readChar(char & x, ReadBuffer & buf)
     ++buf.position();
 }
 
-
 /// Read POD-type in native format
 template <typename T>
 inline void readPODBinary(T & x, ReadBuffer & buf)
 {
     buf.readStrict(reinterpret_cast<char *>(&x), sizeof(x)); /// NOLINT
+}
+
+template <typename T>
+inline void readPODBinaryLittleEndian(T & x, ReadBuffer & buf)
+{
+    buf.readStrict(reinterpret_cast<char *>(&x), sizeof(x)); /// NOLINT
+    if constexpr (std::endian::native == std::endian::big && sizeof(T) >= 2 && (std::is_arithmetic_v<T> || is_decimal<T> || is_over_big_int<T>))
+    {
+        char *start = reinterpret_cast<char *>(&x), *end = start + sizeof(T);
+        std::reverse(start, end);
+    }
 }
 
 template <typename T>

--- a/src/IO/WriteHelpers.cpp
+++ b/src/IO/WriteHelpers.cpp
@@ -62,7 +62,7 @@ void writeIPv6Text(const IPv6 & ip, WriteBuffer & buf)
 
 void writeException(const Exception & e, WriteBuffer & buf, bool with_stack_trace)
 {
-    writeBinary(e.code(), buf);
+    writeBinaryLittleEndian(e.code(), buf);
     writeBinary(String(e.name()), buf);
     writeBinary(e.displayText() + getExtraExceptionInfo(e), buf);
 

--- a/src/IO/WriteHelpers.h
+++ b/src/IO/WriteHelpers.h
@@ -77,6 +77,21 @@ inline void writeChar(char c, size_t n, WriteBuffer & buf)
         buf.position() += count;
     }
 }
+template <typename T>
+inline void writePODBinaryLittleEndian(const T & x, WriteBuffer & buf)
+{
+    if constexpr (std::endian::native == std::endian::big && sizeof(T) >= 2 && (std::is_arithmetic_v<T> || is_decimal<T> || is_over_big_int<T> ))
+    {
+        T tmp(x);
+        char *start = reinterpret_cast<char*>(&tmp);
+        char *end = start + sizeof(T);
+        std::reverse(start, end);
+
+        buf.write(reinterpret_cast<const char *>(&tmp), sizeof(tmp)); /// NOLINT
+    }
+    else
+        buf.write(reinterpret_cast<const char *>(&x), sizeof(x)); /// NOLINT
+}
 
 /// Write POD-type in native format. It's recommended to use only with packed (dense) data types.
 template <typename T>


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
Fix native protocol endian issue.

### Changelog category (leave one):

- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed native protocol endian issue for z build

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
