### PR TITLE
Kusto-phase3: fix core dump when kql function is not complete

### DIFF
--- a/src/Parsers/Kusto/ParserKQLQuery.cpp
+++ b/src/Parsers/Kusto/ParserKQLQuery.cpp
@@ -430,6 +430,8 @@ std::unique_ptr<ParserKQLBase> ParserKQLQuery::getOperator(const std::string_vie
 
 bool ParserKQLQuery::getOperations(Pos & pos, Expected & expected, OperationsPos & operation_pos)
 {
+    if (pos->isEnd())
+        return false;
     if (String table_name(pos->begin, pos->end); table_name == "print" || table_name == "range")
         operation_pos.emplace_back(table_name, pos);
     else
@@ -505,7 +507,8 @@ bool ParserKQLQuery::pre_process(String & source, Pos & pos)
     }
 
     auto end = pos;
-    --end;
+    if (end != begin)
+        --end;
     source = String(begin->begin, end->end);
 
     auto replace = [&](std::string & str, const std::string & from, const std::string & to)

--- a/src/Parsers/Kusto/ParserKQLStatement.cpp
+++ b/src/Parsers/Kusto/ParserKQLStatement.cpp
@@ -80,6 +80,9 @@ bool ParserKQLTaleFunction::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
                 break;
             ++pos;
         }
+        if (pos->isEnd() && paren_count != 0)
+            return false;
+
         kql_statement = String(pos_start->begin, (--pos)->end);
         ++pos;
 


### PR DESCRIPTION

- Bug Fix (user-visible misbehavior in an official stable release)

fixed core dump when kql function is not complete

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
