### PR TITLE
correct `countof` to handle overlapping strings

### DIFF
--- a/src/Functions/Kusto/kqlCountOverlappingSubstrings.cpp
+++ b/src/Functions/Kusto/kqlCountOverlappingSubstrings.cpp
@@ -1,0 +1,94 @@
+#include <Columns/ColumnArray.h>
+#include <Columns/ColumnDecimal.h>
+#include <Columns/ColumnString.h>
+#include <DataTypes/DataTypeString.h>
+#include <DataTypes/DataTypesNumber.h>
+#include <Functions/FunctionFactory.h>
+#include <Functions/FunctionHelpers.h>
+#include <Functions/IFunction.h>
+#include <Functions/Kusto/KqlFunctionBase.h>
+#include <string>
+#include <iostream>
+
+namespace DB
+{
+namespace DB::ErrorCodes
+{
+extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
+extern const int ILLEGAL_TYPE_OF_ARGUMENT;
+}
+
+class FunctionKqlCountOverlappingSubstrings : public IFunction
+{
+public:
+    static constexpr auto name = "kql_count_overlapping_substrings";
+    static FunctionPtr create(ContextPtr context) { return std::make_shared<FunctionKqlCountOverlappingSubstrings>(std::move(context)); }
+
+    explicit FunctionKqlCountOverlappingSubstrings(ContextPtr context_) : context(std::move(context_)) { }
+    ~FunctionKqlCountOverlappingSubstrings() override = default;
+
+    String getName() const override { return name; }
+    size_t getNumberOfArguments() const override { return 2; }
+    bool isVariadic() const override { return false; }
+
+    bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo & /*arguments*/) const override { return false; }
+
+    DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const override
+    {
+        const auto args_length = arguments.size();
+
+        if (args_length != 2)
+        {
+            throw Exception(
+                ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH,
+                "Number of arguments for function {} doesn't match: passed {}, should be 2 more.",
+                getName(),
+                toString(arguments.size()));
+        }
+
+        if (!isString(arguments.at(0).type))
+        {
+            throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Illegal type of argument of function {}", getName());
+        }
+
+        if (!isString(arguments.at(1).type))
+        {
+            throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Illegal type of argument of function {}", getName());
+        }
+
+        return std::make_shared<DataTypeUInt32>();
+    }
+
+    ColumnPtr
+    executeImpl(const ColumnsWithTypeAndName & arguments, [[maybe_unused]] const DataTypePtr & result_type, const size_t input_rows_count) const override
+    {
+        auto result = ColumnUInt32::create();
+        auto & result_column = result->getData();
+
+        for (size_t i = 0; i < input_rows_count; ++i)
+        {
+            uint32_t res = 0;
+
+            const auto source = arguments[0].column->getDataAt(i).toString();
+            const auto search = arguments[1].column->getDataAt(i).toString();
+            std::size_t found = 0;
+
+            while ((found = source.find(search, found)) != std::string::npos)
+            {
+                ++res;
+                ++found;
+            }
+            result_column.push_back(static_cast<UInt32>(res));
+        }
+        return result;
+    }
+
+private:
+    ContextPtr context;
+};
+
+REGISTER_FUNCTION(KqlCountOverlappingSubstrings)
+{
+    factory.registerFunction<FunctionKqlCountOverlappingSubstrings>();
+}
+}

--- a/src/Functions/Kusto/kqlCountOverlappingSubstrings.cpp
+++ b/src/Functions/Kusto/kqlCountOverlappingSubstrings.cpp
@@ -1,21 +1,12 @@
-#include <Columns/ColumnArray.h>
-#include <Columns/ColumnDecimal.h>
-#include <Columns/ColumnString.h>
-#include <DataTypes/DataTypeString.h>
-#include <DataTypes/DataTypesNumber.h>
-#include <Functions/FunctionFactory.h>
-#include <Functions/FunctionHelpers.h>
-#include <Functions/IFunction.h>
-#include <Functions/Kusto/KqlFunctionBase.h>
 #include <string>
-#include <iostream>
+#include <Functions/Kusto/KqlFunctionBase.h>
 
 namespace DB
 {
 namespace DB::ErrorCodes
 {
-extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
-extern const int ILLEGAL_TYPE_OF_ARGUMENT;
+    extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
+    extern const int ILLEGAL_TYPE_OF_ARGUMENT;
 }
 
 class FunctionKqlCountOverlappingSubstrings : public IFunction
@@ -59,8 +50,10 @@ public:
         return std::make_shared<DataTypeUInt32>();
     }
 
-    ColumnPtr
-    executeImpl(const ColumnsWithTypeAndName & arguments, [[maybe_unused]] const DataTypePtr & result_type, const size_t input_rows_count) const override
+    ColumnPtr executeImpl(
+        const ColumnsWithTypeAndName & arguments,
+        [[maybe_unused]] const DataTypePtr & result_type,
+        const size_t input_rows_count) const override
     {
         auto result = ColumnUInt32::create();
         auto & result_column = result->getData();

--- a/src/Functions/Kusto/kqlCountOverlappingSubstrings.cpp
+++ b/src/Functions/Kusto/kqlCountOverlappingSubstrings.cpp
@@ -32,7 +32,7 @@ public:
         {
             throw Exception(
                 ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH,
-                "Number of arguments for function {} doesn't match: passed {}, should be 2 more.",
+                "Number of arguments for function {} doesn't match: passed {}, should be 2.",
                 getName(),
                 toString(arguments.size()));
         }

--- a/src/Parsers/Kusto/KQL_ReleaseNote.md
+++ b/src/Parsers/Kusto/KQL_ReleaseNote.md
@@ -1,4 +1,8 @@
 ## KQL implemented features  
+# June , 2023
+
+## Bugfixes
+- Corrected an issue with `countof` operator where plain string matches were not correctly counting overlapping strings.
 
 # May , 2023  
 

--- a/src/Parsers/Kusto/KustoFunctions/KQLStringFunctions.cpp
+++ b/src/Parsers/Kusto/KustoFunctions/KQLStringFunctions.cpp
@@ -100,7 +100,7 @@ bool CountOf::convertImpl(String & out, IParser::Pos & pos)
     assert(kind == "'normal'" || kind == "'regex'");
 
     if (kind == "'normal'")
-        out = "countSubstrings(" + source + ", " + search + ")";
+        out = "kql_count_overlapping_substrings(" + source + ", " + search + ")";
     else
         out = "countMatches(" + source + ", " + search + ")";
     return true;

--- a/src/Parsers/tests/KQL/gtest_KQL_Operators.cpp
+++ b/src/Parsers/tests/KQL/gtest_KQL_Operators.cpp
@@ -196,11 +196,11 @@ INSTANTIATE_TEST_SUITE_P(ParserKQLQuery_Operators, ParserTest,
         },
         {
             "Customers | project countof('The cat sat on the mat', 'at')",
-            "SELECT countSubstrings('The cat sat on the mat', 'at') AS Column1\nFROM Customers"
+            "SELECT kql_count_overlapping_substrings('The cat sat on the mat', 'at') AS Column1\nFROM Customers"
         },
         {
             "Customers | project countof('The cat sat on the mat', 'at', 'normal')",
-            "SELECT countSubstrings('The cat sat on the mat', 'at') AS Column1\nFROM Customers"
+            "SELECT kql_count_overlapping_substrings('The cat sat on the mat', 'at') AS Column1\nFROM Customers"
         },
         {
             "Customers | project countof('The cat sat on the mat', 'at', 'regex')",

--- a/tests/queries/0_stateless/02366_kql_func_string.reference
+++ b/tests/queries/0_stateless/02366_kql_func_string.reference
@@ -237,6 +237,12 @@ Apple		Skilled Manual	Bachelors	28
 3
 3
 1
+3
+3
+2
+2
+1
+2
 
 -- extract ( https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/extractfunction)
 PINEAPPLE ice cream is 20

--- a/tests/queries/0_stateless/02366_kql_func_string.sql
+++ b/tests/queries/0_stateless/02366_kql_func_string.sql
@@ -213,6 +213,12 @@ print '-- countof (https://docs.microsoft.com/en-us/azure/data-explorer/kusto/qu
 Customers | project countof('The cat sat on the mat', 'at') | take 1;
 Customers | project countof('The cat sat on the mat', 'at', 'normal') | take 1;
 Customers | project countof('The cat sat on the mat', '\\s.he', 'regex') | take 1;
+print countof("aaa", "a");
+print countof("aaaa", "aa");
+print countof("ababa", "ab", "normal");
+print countof("ababa", "aba");
+print countof("ababa", "aba", "regex");
+print countof("abcabc", "a.c", "regex");
 print '';
 print '-- extract ( https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/extractfunction)';
 print extract('(\\b[A-Z]+\\b).+(\\b\\d+)', 0, 'The price of PINEAPPLE ice cream is 20');


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
correct `countof` to handle overlapping strings