### PR TITLE
Fix CRC32(WeakHash) for s390x

### DIFF
--- a/src/Common/HashTable/Hash.h
+++ b/src/Common/HashTable/Hash.h
@@ -57,29 +57,27 @@ inline DB::UInt64 intHash64(DB::UInt64 x)
 
 inline uint32_t s390x_crc32_u8(uint32_t crc, uint8_t v)
 {
-    return crc32_be(crc, reinterpret_cast<unsigned char *>(&v), sizeof(v));
+    return crc32c_le_vx(crc, reinterpret_cast<unsigned char *>(&v), sizeof(v));
 }
 
 inline uint32_t s390x_crc32_u16(uint32_t crc, uint16_t v)
 {
-    return crc32_be(crc, reinterpret_cast<unsigned char *>(&v), sizeof(v));
+    v = std::byteswap(v);
+    return crc32c_le_vx(crc, reinterpret_cast<unsigned char *>(&v), sizeof(v));
 }
 
 inline uint32_t s390x_crc32_u32(uint32_t crc, uint32_t v)
 {
-    return crc32_be(crc, reinterpret_cast<unsigned char *>(&v), sizeof(v));
+    v = std::byteswap(v);
+    return crc32c_le_vx(crc, reinterpret_cast<unsigned char *>(&v), sizeof(v));
 }
 
 inline uint64_t s390x_crc32(uint64_t crc, uint64_t v)
 {
-    uint64_t _crc = crc;
-    uint32_t value_h, value_l;
-    value_h = (v >> 32) & 0xffffffff;
-    value_l = v & 0xffffffff;
-    _crc = crc32_be(static_cast<uint32_t>(_crc), reinterpret_cast<unsigned char *>(&value_h), sizeof(uint32_t));
-    _crc = crc32_be(static_cast<uint32_t>(_crc), reinterpret_cast<unsigned char *>(&value_l), sizeof(uint32_t));
-    return _crc;
+    v = std::byteswap(v);
+    return crc32c_le_vx(static_cast<uint32_t>(crc), reinterpret_cast<unsigned char *>(&v), sizeof(uint64_t));
 }
+
 #endif
 
 /// NOTE: Intel intrinsic can be confusing.


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
WeakHash code on s390x generates different results compared to x86. The reason is that it uses CRC32 (not CRC32C) and "_be" version of library functions, and also it hashes big endian of integers instead of little endian.


### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed WeakHash for s390x.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
