### PR TITLE
Issue 2609:  base64 decode to string should return null for invalid encoded values

### DIFF
--- a/src/Parsers/Kusto/KustoFunctions/KQLStringFunctions.cpp
+++ b/src/Parsers/Kusto/KustoFunctions/KQLStringFunctions.cpp
@@ -43,9 +43,8 @@ bool Base64DecodeToString::convertImpl(String & out, IParser::Pos & pos)
     const String str = getConvertedArgument(fn_name, pos);
 
     out = std::format(
-        "IF ((length({0}) % 4) != 0, NULL, IF (countMatches(substring({0}, 1, length({0}) - 2), '=') > 0, NULL, IF(isValidUTF8(tryBase64Decode({0}) AS decoded_str_{1}),decoded_str_{1}, NULL)))",
-        str,
-        generateUniqueIdentifier());
+        "IF ((length({0}) % 4) != 0, NULL, IF (countMatches(substring({0}, 1, length({0}) - 2), '=') > 0, NULL, IF(isValidUTF8(tryBase64Decode({0}) AS decoded_str),decoded_str, NULL)))",
+        str);
 
     return true;
 }

--- a/src/Parsers/Kusto/KustoFunctions/KQLStringFunctions.cpp
+++ b/src/Parsers/Kusto/KustoFunctions/KQLStringFunctions.cpp
@@ -43,8 +43,9 @@ bool Base64DecodeToString::convertImpl(String & out, IParser::Pos & pos)
     const String str = getConvertedArgument(fn_name, pos);
 
     out = std::format(
-        "IF ((length({0}) % 4) != 0, NULL, IF (countMatches(substring({0}, 1, length({0}) - 2), '=') > 0, NULL, tryBase64Decode({0})))",
-        str);
+        "IF ((length({0}) % 4) != 0, NULL, IF (countMatches(substring({0}, 1, length({0}) - 2), '=') > 0, NULL, IF(isValidUTF8(tryBase64Decode({0}) AS decoded_str_{1}),decoded_str_{1}, NULL)))",
+        str,
+        generateUniqueIdentifier());
 
     return true;
 }

--- a/src/Parsers/Kusto/KustoFunctions/KQLStringFunctions.cpp
+++ b/src/Parsers/Kusto/KustoFunctions/KQLStringFunctions.cpp
@@ -43,8 +43,9 @@ bool Base64DecodeToString::convertImpl(String & out, IParser::Pos & pos)
     const String str = getConvertedArgument(fn_name, pos);
 
     out = std::format(
-        "IF ((length({0}) % 4) != 0, NULL, IF (countMatches(substring({0}, 1, length({0}) - 2), '=') > 0, NULL, IF(isValidUTF8(tryBase64Decode({0}) AS decoded_str),decoded_str, NULL)))",
-        str);
+        "IF ((length({0}) % 4) != 0, NULL, IF (countMatches(substring({0}, 1, length({0}) - 2), '=') > 0, NULL, IF(isValidUTF8(tryBase64Decode({0}) AS decoded_str_{1}),decoded_str_{1}, NULL)))",
+        str,
+        generateUniqueIdentifier());
 
     return true;
 }

--- a/src/Parsers/tests/KQL/gtest_KQL_StringFunctions.cpp
+++ b/src/Parsers/tests/KQL/gtest_KQL_StringFunctions.cpp
@@ -20,7 +20,7 @@ INSTANTIATE_TEST_SUITE_P(ParserKQLQuery_String, ParserTest,
         },
         {
             "print res = base64_decode_tostring('S3VzdG8====')",
-            "SELECT IF((length('S3VzdG8====') % 4) != 0, NULL, IF(countMatches(substring('S3VzdG8====', 1, length('S3VzdG8====') - 2), '=') > 0, NULL, tryBase64Decode('S3VzdG8===='))) AS res"
+            "SELECT IF((length('S3VzdG8====') % 4) != 0, NULL, IF(countMatches(substring('S3VzdG8====', 1, length('S3VzdG8====') - 2), '=') > 0, NULL, IF(isValidUTF8(tryBase64Decode('S3VzdG8====') AS decoded_str), decoded_str, NULL))) AS res"
         },
         {
             "print replace_regex('Hello, World!', '.', '\\0\\0')",

--- a/src/Parsers/tests/KQL/gtest_KQL_StringFunctions.cpp
+++ b/src/Parsers/tests/KQL/gtest_KQL_StringFunctions.cpp
@@ -2,6 +2,16 @@
 
 #include <Parsers/Kusto/ParserKQLStatement.h>
 
+INSTANTIATE_TEST_SUITE_P(ParserKQLQuery_IP, ParserRegexTest,
+    ::testing::Combine(
+        ::testing::Values(std::make_shared<DB::ParserKQLStatement>()),
+        ::testing::ValuesIn(std::initializer_list<ParserTestCase>{
+        {
+            "print res = base64_decode_tostring('S3VzdG8====')",
+            R"(SELECT IF\(\(length\(\'S3VzdG8====\'\) % 4\) != 0, NULL, IF\(countMatches\(substring\(\'S3VzdG8====\', 1, length\(\'S3VzdG8====\'\) - 2\), \'=\'\) > 0, NULL, IF\(isValidUTF8\(tryBase64Decode\(\'S3VzdG8====\'\) AS decoded_str_\d+\), decoded_str_\d+, NULL\)\)\) AS res)"
+        },
+})));
+
 INSTANTIATE_TEST_SUITE_P(ParserKQLQuery_String, ParserTest,
     ::testing::Combine(
         ::testing::Values(std::make_shared<DB::ParserKQLStatement>()),
@@ -17,10 +27,6 @@ INSTANTIATE_TEST_SUITE_P(ParserKQLQuery_String, ParserTest,
         {
             "print base64_decode_toarray('S3VzdG8=')",
             "SELECT IF((length('S3VzdG8=') % 4) != 0, [NULL], IF(length(tryBase64Decode('S3VzdG8=')) = 0, [NULL], IF(countMatches(substring('S3VzdG8=', 1, length('S3VzdG8=') - 2), '=') > 0, [NULL], arrayMap(x -> reinterpretAsUInt8(x), splitByRegexp('', base64Decode(assumeNotNull(IF(length(tryBase64Decode('S3VzdG8=')) = 0, '', 'S3VzdG8=')))))))) AS print_0"
-        },
-        {
-            "print res = base64_decode_tostring('S3VzdG8====')",
-            "SELECT IF((length('S3VzdG8====') % 4) != 0, NULL, IF(countMatches(substring('S3VzdG8====', 1, length('S3VzdG8====') - 2), '=') > 0, NULL, IF(isValidUTF8(tryBase64Decode('S3VzdG8====') AS decoded_str), decoded_str, NULL))) AS res"
         },
         {
             "print replace_regex('Hello, World!', '.', '\\0\\0')",

--- a/tests/ci/workflow_approve_rerun_lambda/app.py
+++ b/tests/ci/workflow_approve_rerun_lambda/app.py
@@ -137,6 +137,7 @@ TRUSTED_CONTRIBUTORS = {
         "mcmajam",
         "bemitc",
         "vibhaKulka",
+        "bhavnajindal"
     ]
 }
 

--- a/tests/queries/0_stateless/02366_kql_func_string.reference
+++ b/tests/queries/0_stateless/02366_kql_func_string.reference
@@ -308,6 +308,7 @@ S3VzdG8x
 
 Kusto1
 \N
+\N
 -- parse_url() same as ADX
 {"Scheme":"scheme","Host":"host","Port":"1234","Path":"/this/is/a/path","Username":"username","Password":"password","Query Parameters":{"k1":"v1","k2":"v2"},"Fragment":"fragment"}
 {"Scheme":"","Host":"","Port":"","Path":"","Username":"","Password":"","Query Parameters":{},"Fragment":""}

--- a/tests/queries/0_stateless/02366_kql_func_string.sql
+++ b/tests/queries/0_stateless/02366_kql_func_string.sql
@@ -290,6 +290,7 @@ print '-- base64_decode_tostring';
 print base64_decode_tostring('');
 print base64_decode_tostring('S3VzdG8x');
 print base64_decode_tostring('S3VzdG8====');
+print base64_decode_tostring('U3RyaW5n0KHR0tGA0L7Rh9C60LA=');
 print '-- parse_url() same as ADX';
 print parse_url('scheme://username:password@host:1234/this/is/a/path?k1=v1&k2=v2#fragment');
 print parse_url('');


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Added validation in base64_decode_tostring method to return a valid decoded UTF8 string else return NULL
- Functional test
- Unit test

Issue Link: https://github.ibm.com/ClickHouse/issue-repo/issues/2609

Query:
`print Empty=base64_decode_tostring("U3RyaW5n0KHR0tGA0L7Rh9C60LA=");`

Output:
`NULL`


