### PR TITLE
Issue 2846: wildcard to Regex is not correct in the project-away operator

### DIFF
--- a/src/Parsers/Kusto/ParserKQLProjectAway.cpp
+++ b/src/Parsers/Kusto/ParserKQLProjectAway.cpp
@@ -27,7 +27,7 @@ bool ParserKQLProjectAway::parseImpl(Pos & pos, ASTPtr & node, Expected & /*expe
         if (regex_column == column)
             regular_columns.push_back(column);
         else
-            wildcard_columns.push_back("'" + regex_column + "'");
+            wildcard_columns.push_back("'^" + regex_column + "$'");
     };
 
     while (!pos->isEnd() && pos->type != TokenType::PipeMark && pos->type != TokenType::Semicolon)

--- a/src/Parsers/Kusto/ParserKQLProjectAway.cpp
+++ b/src/Parsers/Kusto/ParserKQLProjectAway.cpp
@@ -27,7 +27,7 @@ bool ParserKQLProjectAway::parseImpl(Pos & pos, ASTPtr & node, Expected & /*expe
         if (regex_column == column)
             regular_columns.push_back(column);
         else
-            wildcard_columns.push_back("'^" + regex_column + "$'");
+            wildcard_columns.push_back("'" + regex_column + "'");
     };
 
     while (!pos->isEnd() && pos->type != TokenType::PipeMark && pos->type != TokenType::Semicolon)

--- a/src/Parsers/Kusto/Utilities.cpp
+++ b/src/Parsers/Kusto/Utilities.cpp
@@ -38,6 +38,7 @@ void setSelectAll(ASTSelectQuery & select_query)
 String wildcardToRegex(const String & wildcard)
 {
     String regex;
+    regex += '^';
     for (char c : wildcard)
     {
         if (c == '*')
@@ -58,6 +59,7 @@ String wildcardToRegex(const String & wildcard)
             regex += c;
         }
     }
+    regex += '$';
     return regex;
 }
 

--- a/src/Parsers/tests/KQL/gtest_KQL_ProjectAway.cpp
+++ b/src/Parsers/tests/KQL/gtest_KQL_ProjectAway.cpp
@@ -16,23 +16,23 @@ INSTANTIATE_TEST_SUITE_P(ParserKQLQuery_ProjectAway, ParserTest,
         },
         {
             "Customers | project-away *Name",
-            "SELECT * EXCEPT '.*Name'\nFROM Customers"
+            "SELECT * EXCEPT '^.*Name$'\nFROM Customers"
         },
         {
             "Customers | project-away *Name, *tion",
-            "SELECT * EXCEPT '.*Name'\nFROM\n(\n    SELECT * EXCEPT '.*tion'\n    FROM Customers\n)"
+            "SELECT * EXCEPT '^.*Name$'\nFROM\n(\n    SELECT * EXCEPT '^.*tion$'\n    FROM Customers\n)"
         },
         {
             "Customers | project-away *Name, Age",
-            "SELECT * EXCEPT Age\nFROM\n(\n    SELECT * EXCEPT '.*Name'\n    FROM Customers\n)"
+            "SELECT * EXCEPT Age\nFROM\n(\n    SELECT * EXCEPT '^.*Name$'\n    FROM Customers\n)"
         },
         {
             "Customers | project-away *Name, Age, Education",
-            "SELECT * EXCEPT (Age, Education)\nFROM\n(\n    SELECT * EXCEPT '.*Name'\n    FROM Customers\n)"
+            "SELECT * EXCEPT (Age, Education)\nFROM\n(\n    SELECT * EXCEPT '^.*Name$'\n    FROM Customers\n)"
         },
         {
             "Customers | project-away *irstName, Age, *astName, Education",
-            "SELECT * EXCEPT (Age, Education)\nFROM\n(\n    SELECT * EXCEPT '.*astName'\n    FROM\n    (\n        SELECT * EXCEPT '.*irstName'\n        FROM Customers\n    )\n)"
+            "SELECT * EXCEPT (Age, Education)\nFROM\n(\n    SELECT * EXCEPT '^.*astName$'\n    FROM\n    (\n        SELECT * EXCEPT '^.*irstName$'\n        FROM Customers\n    )\n)"
         },
         {
             "Customers | where Age< 30 | limit 2 | project-away FirstName",

--- a/tests/ci/workflow_approve_rerun_lambda/app.py
+++ b/tests/ci/workflow_approve_rerun_lambda/app.py
@@ -137,7 +137,7 @@ TRUSTED_CONTRIBUTORS = {
         "mcmajam",
         "bemitc",
         "vibhaKulka",
-        "bhavnajindal"
+        "bhavnajindal",
     ]
 }
 

--- a/tests/queries/0_stateless/02366_kql_projectaway.reference
+++ b/tests/queries/0_stateless/02366_kql_projectaway.reference
@@ -27,3 +27,12 @@ Theodore	28
 
 10-- remove columns after extend
 Skilled Manual	Bachelors	28	Theodore Diaz
+
+11-- remove two columns by one wildcard in postfix
+abc_Qwerty	abc_Qwerty_xyz	1
+
+12-- remove two columns by one wildcard in prefix
+Qwerty_xyz	abc_Qwerty_xyz	1
+
+13-- remove four columns by wildcard in prefix and postfix
+1

--- a/tests/queries/0_stateless/02366_kql_projectaway.sql
+++ b/tests/queries/0_stateless/02366_kql_projectaway.sql
@@ -10,6 +10,18 @@ CREATE TABLE Customers
 
 INSERT INTO Customers VALUES ('Theodore','Diaz','Skilled Manual','Bachelors',28);
 
+DROP TABLE IF EXISTS Events;
+CREATE TABLE Events
+(    
+    Test Nullable(String),
+    abc_Test String, 
+    Test_xyz String,
+    abc_Test_xyz String,
+    test_lowercase Nullable(UInt8)
+) ENGINE = Memory;
+
+INSERT INTO Events VALUES ('Qwerty','abc_Qwerty','Qwerty_xyz','abc_Qwerty_xyz',1);
+
 set dialect = 'kusto';
 print '1-- remove one column';
 Customers | project-away FirstName;
@@ -40,3 +52,12 @@ Customers|summarize sum(Age), avg(Age) by FirstName | project-away sum_Age;
 print '';
 print '10-- remove columns after extend';
 Customers|extend FullName = strcat(FirstName,' ',LastName) | project-away FirstName, LastName;
+print '';
+print '11-- remove two columns by one wildcard in postfix';
+Events | project-away Test*;
+print '';
+print '12-- remove two columns by one wildcard in prefix';
+Events | project-away *Test;
+print '';
+print '13-- remove four columns by wildcard in prefix and postfix';
+Events | project-away *Test*;


### PR DESCRIPTION
Issue Link: https://github.ibm.com/ClickHouse/issue-repo/issues/2846

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

- Added the Regex anchors "**^**"  and "**$**" to the column names for conversion to Regex from wildcard in ProjectAway KQL operator

Query
`events| project test=1, some_other_test=2, temp=3 | project-away test* | take 1`

SQL
```
SELECT *
FROM
(
    SELECT * EXCEPT '^test.*$'
    FROM
    (
        SELECT
            1 AS test,
            2 AS some_other_test,
            3 AS temp
        FROM events
    )
)
LIMIT 1
```




