### PR TITLE
external_aggregation_fix

### DIFF
--- a/src/Common/HashTable/TwoLevelStringHashTable.h
+++ b/src/Common/HashTable/TwoLevelStringHashTable.h
@@ -113,14 +113,20 @@ public:
                 if ((reinterpret_cast<uintptr_t>(p) & 2048) == 0)
                 {
                     memcpy(&n[0], p, 8);
-                    n[0] &= -1ULL >> s;
-                }
+                	if constexpr (std::endian::native == std::endian::little)
+						n[0] &= -1ULL >> s;
+					else
+						n[0] &= -1ULL << s;
+				}
                 else
                 {
                     const char * lp = x.data + x.size - 8;
                     memcpy(&n[0], lp, 8);
-                    n[0] >>= s;
-                }
+                	if constexpr (std::endian::native == std::endian::little)
+						n[0] >>= s;
+					else
+						n[0] <<= s;
+				}
                 auto res = hash(k8);
                 auto buck = getBucketFromHash(res);
                 keyHolderDiscardKey(key_holder);
@@ -131,8 +137,11 @@ public:
                 memcpy(&n[0], p, 8);
                 const char * lp = x.data + x.size - 8;
                 memcpy(&n[1], lp, 8);
-                n[1] >>= s;
-                auto res = hash(k16);
+                if constexpr (std::endian::native == std::endian::little)
+					n[1] >>= s;
+				else
+					n[1] <<= s;
+				auto res = hash(k16);
                 auto buck = getBucketFromHash(res);
                 keyHolderDiscardKey(key_holder);
                 return func(self.impls[buck].m2, k16, res);
@@ -142,8 +151,11 @@ public:
                 memcpy(&n[0], p, 16);
                 const char * lp = x.data + x.size - 8;
                 memcpy(&n[2], lp, 8);
-                n[2] >>= s;
-                auto res = hash(k24);
+                if constexpr (std::endian::native == std::endian::little)
+					n[2] >>= s;
+				else
+					n[2] <<= s;
+				auto res = hash(k24);
                 auto buck = getBucketFromHash(res);
                 keyHolderDiscardKey(key_holder);
                 return func(self.impls[buck].m3, k24, res);


### PR DESCRIPTION
00284_external_aggregation was failing on the s390x. It seems the TwoLevelStringHashTable.h didn't have the endian fix for the dispatch method similar to that of the StringHashTable.h

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
* build improvement

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
