### PR TITLE
Fix ForEach state for s390x

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionForEach.h
+++ b/src/AggregateFunctions/AggregateFunctionForEach.h
@@ -240,7 +240,7 @@ public:
     void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
     {
         const AggregateFunctionForEachData & state = data(place);
-        writeBinary(state.dynamic_array_size, buf);
+        writeBinaryLittleEndian(state.dynamic_array_size, buf);
 
         const char * nested_state = state.array_of_aggregate_datas;
         for (size_t i = 0; i < state.dynamic_array_size; ++i)
@@ -255,7 +255,7 @@ public:
         AggregateFunctionForEachData & state = data(place);
 
         size_t new_size = 0;
-        readBinary(new_size, buf);
+        readBinaryLittleEndian(new_size, buf);
 
         ensureAggregateData(place, new_size, *arena);
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
ForEach aggregate state for s390x uses big-endian state which fails the functional test 01381_for_each_with_states.
The fix uses little-endian in reading and writing states. 

### Changelog category (leave one):

- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed ForEach aggregate state for s390x

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
