### PR TITLE
[Issue 2525]: dcount, dcountif aren't using HyperLogLog

### DIFF
--- a/src/Parsers/Kusto/KustoFunctions/KQLAggregationFunctions.cpp
+++ b/src/Parsers/Kusto/KustoFunctions/KQLAggregationFunctions.cpp
@@ -1,10 +1,10 @@
 #include "KQLAggregationFunctions.h"
 #include <Parsers/Kusto/KustoFunctions/IParserKQLFunction.h>
 
-#include <Common/StringUtils/StringUtils.h>
-#include <ranges>
 #include <format>
 #include <numeric>
+#include <ranges>
+#include <Common/StringUtils/StringUtils.h>
 
 namespace DB::ErrorCodes
 {
@@ -19,20 +19,19 @@ void checkAccuracy(const std::optional<std::string> & accuracy)
         throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "only accuracy of 4 is supported");
 }
 
-uint mapPrecisionAccuracy(const std::optional<std::string> & accuracy){
-    if(accuracy){
-        if(*accuracy == "0")
-            return 12;
-        else if(*accuracy == "1")
-            return 14;
-        else if(*accuracy == "2")
-            return 16;
-        else if(*accuracy == "3")
-            return 17;
-        else
-            return 18;
-    }
-    return 18;
+uint mapPrecisionAccuracy(const std::optional<std::string> & accuracy)
+{
+    if (!accuracy)
+        return 14; //default accuracy is 1
+
+    if (*accuracy == "0")
+        return 12;
+    else if (*accuracy == "2")
+        return 16;
+    else if (*accuracy == "3")
+        return 17;
+    else
+        return 14;
 }
 }
 
@@ -125,7 +124,7 @@ bool DCount::convertImpl(String & out, IParser::Pos & pos)
     const auto value = getArgument(fn_name, pos);
     const auto accuracy = getOptionalArgument(fn_name, pos);
 
-    out = std::format("uniqCombined64({})({})",mapPrecisionAccuracy(accuracy),value);
+    out = std::format("uniqCombined64({})({})", mapPrecisionAccuracy(accuracy), value);
     return true;
 }
 
@@ -141,7 +140,7 @@ bool DCountIf::convertImpl(String & out, IParser::Pos & pos)
     String condition = getConvertedArgument(fn_name, pos);
 
     const auto accuracy = getOptionalArgument(fn_name, pos);
-    out = std::format("uniqCombined64If({})({},({}))",mapPrecisionAccuracy(accuracy),value,condition);
+    out = std::format("uniqCombined64If({})({},({}))", mapPrecisionAccuracy(accuracy), value, condition);
     return true;
 }
 

--- a/src/Parsers/tests/KQL/gtest_KQL_AggregateFunctions.cpp
+++ b/src/Parsers/tests/KQL/gtest_KQL_AggregateFunctions.cpp
@@ -96,15 +96,15 @@ INSTANTIATE_TEST_SUITE_P(ParserKQLQuery_Aggregate, ParserTest,
         },
         {
             "Customers | summarize take_anyif(FirstName, LastName has 'Diaz'), dcount(FirstName)"
-            "SELECT\n    anyIf(FirstName, hasTokenCaseInsensitive(LastName, 'Diaz')) AS take_anyif_FirstName,\n    countDistinct(FirstName) AS dcount_FirstName\nFROM Customers"
+            "SELECT\n    anyIf(FirstName, hasTokenCaseInsensitive(LastName, 'Diaz')) AS take_anyif_FirstName,\n    uniqCombined64(18)(FirstName) AS dcount_FirstName\nFROM Customers"
 	    },
 	    {
             "Customers | summarize dcount(Education, 2)"
-            "SELECT countDistinct(Education, 2) AS dcount_Education\nFROM Customers"
+            "SELECT uniqCombined64(16)(Education) AS dcount_Education\nFROM Customers"
 	    },
 	    {
             "Customers | summarize dcountif(Education, Occupation=='Professional', 2)"
-            "SELECT countDistinct(Education, Occupation = 'Professional', 2) AS dcountif_Education\nFROM Customers"
+            "SELECT uniqCombined64If(16)(Education, Occupation = 'Professional') AS dcountif_Education\nFROM Customers"
         },
         {	
             "Customers | summarize by FirstName, LastName, Age",

--- a/tests/queries/0_stateless/02366_kql_summarize.reference
+++ b/tests/queries/0_stateless/02366_kql_summarize.reference
@@ -21,7 +21,7 @@ Management abcd defg	33
 4
 4
 2
-6
+2
 40	2
 30	4
 20	6


### PR DESCRIPTION
Issue Link: https://github.ibm.com/ClickHouse/issue-repo/issues/2525

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed `dcount` and `dcountIf` to use uniqueCombined64. uniqueCombined64 in ClickHouse uses HyperLoglog  to compute the estimated cardinality.

