### PR TITLE
Fixed the wildcardToRegex method to return nullopt in case the the st…

### DIFF
--- a/src/Parsers/Kusto/ParserKQLProjectAway.cpp
+++ b/src/Parsers/Kusto/ParserKQLProjectAway.cpp
@@ -23,7 +23,8 @@ bool ParserKQLProjectAway::parseImpl(Pos & pos, ASTPtr & node, Expected & /*expe
     auto append_columns = [&regular_columns, &wildcard_columns](Pos & begin, Pos & end)
     {
         const auto column = String(begin->begin, end->end);
-        if(const auto regex_column = wildcardToRegex(column)){
+        if (const auto regex_column = wildcardToRegex(column))
+        {
             wildcard_columns.push_back("'" + *regex_column + "'");
         }
         else

--- a/src/Parsers/Kusto/ParserKQLProjectAway.cpp
+++ b/src/Parsers/Kusto/ParserKQLProjectAway.cpp
@@ -24,10 +24,11 @@ bool ParserKQLProjectAway::parseImpl(Pos & pos, ASTPtr & node, Expected & /*expe
     {
         const auto column = String(begin->begin, end->end);
         const auto regex_column = wildcardToRegex(column);
-        if (regex_column == column)
-            regular_columns.push_back(column);
+        if(regex_column.has_value()){
+            wildcard_columns.push_back("'" + regex_column.value() + "'");
+        }
         else
-            wildcard_columns.push_back("'" + regex_column + "'");
+            regular_columns.push_back(column);
     };
 
     while (!pos->isEnd() && pos->type != TokenType::PipeMark && pos->type != TokenType::Semicolon)

--- a/src/Parsers/Kusto/ParserKQLProjectAway.cpp
+++ b/src/Parsers/Kusto/ParserKQLProjectAway.cpp
@@ -23,9 +23,8 @@ bool ParserKQLProjectAway::parseImpl(Pos & pos, ASTPtr & node, Expected & /*expe
     auto append_columns = [&regular_columns, &wildcard_columns](Pos & begin, Pos & end)
     {
         const auto column = String(begin->begin, end->end);
-        const auto regex_column = wildcardToRegex(column);
-        if(regex_column.has_value()){
-            wildcard_columns.push_back("'" + regex_column.value() + "'");
+        if(const auto regex_column = wildcardToRegex(column)){
+            wildcard_columns.push_back("'" + *regex_column + "'");
         }
         else
             regular_columns.push_back(column);

--- a/src/Parsers/Kusto/Utilities.cpp
+++ b/src/Parsers/Kusto/Utilities.cpp
@@ -39,24 +39,24 @@ std::optional<String> wildcardToRegex(const String & wildcard)
 {
     String regex;
     regex += '^';
-    bool hasWildcard = false;
+    bool has_wildcard = false;
     for (char c : wildcard)
     {
         if (c == '*')
         {
             regex += ".*";
-            hasWildcard = true;
+            has_wildcard = true;
         }
         else if (c == '?')
         {
             regex += ".";
-            hasWildcard = true;
+            has_wildcard = true;
         }
         else if (c == '.' || c == '+' || c == '(' || c == ')' || c == '[' || c == ']' || c == '\\' || c == '^' || c == '$')
         {
             regex += "\\";
             regex += c;
-            hasWildcard = true;
+            has_wildcard = true;
         }
         else
         {
@@ -65,7 +65,7 @@ std::optional<String> wildcardToRegex(const String & wildcard)
     }
     regex += '$';
 
-    if(hasWildcard)
+    if(has_wildcard)
         return regex;
 
     return {};

--- a/src/Parsers/Kusto/Utilities.cpp
+++ b/src/Parsers/Kusto/Utilities.cpp
@@ -65,7 +65,7 @@ std::optional<String> wildcardToRegex(const String & wildcard)
     }
     regex += '$';
 
-    if(has_wildcard)
+    if (has_wildcard)
         return regex;
 
     return {};

--- a/src/Parsers/Kusto/Utilities.cpp
+++ b/src/Parsers/Kusto/Utilities.cpp
@@ -35,24 +35,28 @@ void setSelectAll(ASTSelectQuery & select_query)
     select_query.setExpression(ASTSelectQuery::Expression::SELECT, std::move(expression_list));
 }
 
-String wildcardToRegex(const String & wildcard)
+std::optional<String> wildcardToRegex(const String & wildcard)
 {
     String regex;
     regex += '^';
+    bool hasWildcard = false;
     for (char c : wildcard)
     {
         if (c == '*')
         {
             regex += ".*";
+            hasWildcard = true;
         }
         else if (c == '?')
         {
             regex += ".";
+            hasWildcard = true;
         }
         else if (c == '.' || c == '+' || c == '(' || c == ')' || c == '[' || c == ']' || c == '\\' || c == '^' || c == '$')
         {
             regex += "\\";
             regex += c;
+            hasWildcard = true;
         }
         else
         {
@@ -60,7 +64,11 @@ String wildcardToRegex(const String & wildcard)
         }
     }
     regex += '$';
-    return regex;
+
+    if(hasWildcard)
+        return regex;
+
+    return {};
 }
 
 ASTPtr wrapInSelectWithUnion(const ASTPtr & select_query)

--- a/src/Parsers/Kusto/Utilities.h
+++ b/src/Parsers/Kusto/Utilities.h
@@ -8,6 +8,6 @@ namespace DB
 String extractLiteralArgumentWithoutQuotes(const std::string & function_name, IParser::Pos & pos);
 String extractTokenWithoutQuotes(IParser::Pos & pos);
 void setSelectAll(ASTSelectQuery & select_query);
-String wildcardToRegex(const String & wildcard);
+std::optional<String> wildcardToRegex(const String & wildcard);
 ASTPtr wrapInSelectWithUnion(const ASTPtr & select_query);
 }


### PR DESCRIPTION
…ring does not contain any wildcard

Related to Issue: https://github.ibm.com/ClickHouse/issue-repo/issues/2846

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Problem: The recent changes in PR# 359(https://github.com/ClibMouse/ClickHouse/pull/359) to method wildcardToRegex would convert every string into a valid Regex irrespective of whether it contained any wildcard character. This could potentially result in some performance issues as the wildcard columns are converted to subqueries whereas regular columns aren't.

Fix: The wildcardToRegex now has the return-type of std::optional<String>. It will only return a valid Regex if the staring contained any wildcard chars. Otherwise it returns {}

Tests:
All unit tests and functional tests now pass as expected. 

