### PR TITLE
check for accepted values for accuracy in dcount,dcountif

### DIFF
--- a/src/Parsers/Kusto/KustoFunctions/KQLAggregationFunctions.cpp
+++ b/src/Parsers/Kusto/KustoFunctions/KQLAggregationFunctions.cpp
@@ -38,8 +38,8 @@ uint mapPrecisionAccuracy(const std::optional<std::string> & accuracy)
     else
         throw DB::Exception(
             DB::ErrorCodes::BAD_ARGUMENTS,
-            "Argument 2 must be a constant integer with value 0, 1, 2, 3 or 4 (0 = fast , 1 = default, 2 = accurate, 3 = extra accurate, 4 "
-            "= super accurate");
+            "Accuracy argument must be a constant integer with value 0, 1, 2, 3 or 4 (0 = fast , 1 = default, 2 = accurate, 3 = extra accurate, 4 "
+            "= super accurate)");
 }
 }
 

--- a/src/Parsers/Kusto/KustoFunctions/KQLAggregationFunctions.cpp
+++ b/src/Parsers/Kusto/KustoFunctions/KQLAggregationFunctions.cpp
@@ -9,6 +9,7 @@
 namespace DB::ErrorCodes
 {
 extern const int NOT_IMPLEMENTED;
+extern const int BAD_ARGUMENTS;
 }
 
 namespace
@@ -26,12 +27,19 @@ uint mapPrecisionAccuracy(const std::optional<std::string> & accuracy)
 
     if (*accuracy == "0")
         return 12;
+    else if (*accuracy == "1")
+        return 14;
     else if (*accuracy == "2")
         return 16;
     else if (*accuracy == "3")
         return 17;
+    else if (*accuracy == "4")
+        return 18;
     else
-        return 14;
+        throw DB::Exception(
+            DB::ErrorCodes::BAD_ARGUMENTS,
+            "Argument 2 must be a constant integer with value 0, 1, 2, 3 or 4 (0 = fast , 1 = default, 2 = accurate, 3 = extra accurate, 4 "
+            "= super accurate");
 }
 }
 

--- a/tests/queries/0_stateless/02366_kql_summarize.sql
+++ b/tests/queries/0_stateless/02366_kql_summarize.sql
@@ -59,8 +59,10 @@ Customers | summarize MyAvg = avgif(Age, Age<40) by Occupation;
 Customers | summarize MySum = sumif(Age, Age<40) by Occupation;
 Customers | summarize dcount(Education);
 Customers | summarize dcount(Education, 2);
+Customers | summarize dcount(Education, 10);  -- { clientError 36 }
 Customers | summarize dcountif(Education, Occupation=='Professional');
 Customers | summarize dcountif(Education, Occupation=='Professional', 2);
+Customers | summarize dcountif(Education, Occupation=='Professional', -1); -- { clientError 36 }
 Customers | summarize count_ = count() by bin(Age, 10) | order by count_ asc;
 Customers | summarize job_count = count() by Occupation | where job_count > 0;
 Customers | summarize 'Edu Count'=count() by Education | sort by 'Edu Count' desc; -- { clientError 62 }


### PR DESCRIPTION
Issue: https://github.ibm.com/ClickHouse/issue-repo/issues/2524

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Added exception handling to handle cases when the argument value provided for accuracy is not one of the accepted values (0,1,2,3,4)

Example use: 

Query 1:
`StormEvents | summarize dcount(EventType, -1);`

Output
```
Exception on client:
Code: 36. DB::Exception: Argument 2 must be a constant integer with value 0, 1, 2, 3 or 4 (0 = fast , 1 = default, 2 = accurate, 3 = extra accurate, 4 = super accurate. (BAD_ARGUMENTS)
```

Query 2:
`StormEvents | summarize dcountif(EventType, 8, x=10);`

Output
```
Exception on client:
Code: 36. DB::Exception: Argument 2 must be a constant integer with value 0, 1, 2, 3 or 4 (0 = fast , 1 = default, 2 = accurate, 3 = extra accurate, 4 = super accurate. (BAD_ARGUMENTS)
```

