### PR TITLE
Fix function transform for s390x

### DIFF
--- a/src/Functions/transform.cpp
+++ b/src/Functions/transform.cpp
@@ -774,7 +774,11 @@ namespace
                         /// Field may be of Float type, but for the purpose of bitwise equality we can treat them as UInt64
                         StringRef ref = cache.from_column->getDataAt(i);
                         UInt64 key = 0;
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+                        memcpy(reinterpret_cast<unsigned char *>(&key) + sizeof(UInt64) - ref.size, ref.data, ref.size);
+#else
                         memcpy(&key, ref.data, ref.size);
+#endif
                         table[key] = i;
                     }
                 }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
On s390x, function transform has endian-issue which causes the failure of functional test `02542_case_no_else`. The reason is that memcpy() in src/Functions/transform.cpp:777 uses wrong starting position to do the memory copy.
The fix is to correct the starting position for the memcpy() call.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed endian issue in function transform for s390x.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
