### PR TITLE
I2527: Fixed NaN issue in variance functions

### DIFF
--- a/src/Parsers/Kusto/KustoFunctions/KQLAggregationFunctions.cpp
+++ b/src/Parsers/Kusto/KustoFunctions/KQLAggregationFunctions.cpp
@@ -604,7 +604,11 @@ bool Variance::convertImpl(String & out, IParser::Pos & pos)
         return false;
 
     const String expr = getArgument(fn_name, pos);
-    out = std::format("IF (isNaN(varSamp({0}) AS variance_{1}), 0, variance_{1})", expr, generateUniqueIdentifier());
+    out = std::format(
+        "IF (isNaN(varSamp(if(toTypeName({0}) = 'Nullable(Nothing)', throwIf(toTypeName({0}) = 'Nullable(Nothing)', "
+        "'summarize operator: Failed to resolve scalar expression named null'), {0})) AS variance_{1}), 0, variance_{1})",
+        expr,
+        generateUniqueIdentifier());
 
     return true;
 }
@@ -617,7 +621,12 @@ bool VarianceIf::convertImpl(String & out, IParser::Pos & pos)
 
     const String expr = getArgument(fn_name, pos);
     const String predicate = getArgument(fn_name, pos);
-    out = std::format("IF (isNaN(varSampIf({0}, {1}) AS variance_{2}), 0, variance_{2})", expr, predicate, generateUniqueIdentifier());
+    out = std::format(
+        "IF (isNaN(varSampIf((if(toTypeName({0}) = 'Nullable(Nothing)', throwIf(toTypeName({0}) = 'Nullable(Nothing)', "
+        "'summarize operator: Failed to resolve scalar expression named null'), {0})), {1}) AS variance_{2}), 0, variance_{2})",
+        expr,
+        predicate,
+        generateUniqueIdentifier());
 
     return true;
 }
@@ -629,7 +638,11 @@ bool VarianceP::convertImpl(String & out, IParser::Pos & pos)
         return false;
 
     const String expr = getArgument(fn_name, pos);
-    out = std::format("IF (isNaN(varPop({0}) AS variance_{1}), 0, variance_{1})", expr, generateUniqueIdentifier());
+    out = std::format(
+        "IF (isNaN(varPop(if(toTypeName({0}) = 'Nullable(Nothing)', throwIf(toTypeName({0}) = 'Nullable(Nothing)', "
+        "'summarize operator: Failed to resolve scalar expression named null'), {0})) AS variance_{1}), 0, variance_{1})",
+        expr,
+        generateUniqueIdentifier());
 
     return true;
 }

--- a/src/Parsers/Kusto/KustoFunctions/KQLAggregationFunctions.cpp
+++ b/src/Parsers/Kusto/KustoFunctions/KQLAggregationFunctions.cpp
@@ -599,7 +599,14 @@ bool TakeAnyIf::convertImpl(String & out, IParser::Pos & pos)
 
 bool Variance::convertImpl(String & out, IParser::Pos & pos)
 {
-    return directMapping(out, pos, "varSamp");
+    const String fn_name = getKQLFunctionName(pos);
+    if (fn_name.empty())
+        return false;
+
+    const String expr = getArgument(fn_name, pos);
+    out = std::format("IF (isNaN(varSamp({0}) AS variance_{1}), 0, variance_{1})", expr, generateUniqueIdentifier());
+
+    return true;
 }
 
 bool VarianceIf::convertImpl(String & out, IParser::Pos & pos)
@@ -610,14 +617,21 @@ bool VarianceIf::convertImpl(String & out, IParser::Pos & pos)
 
     const String expr = getArgument(fn_name, pos);
     const String predicate = getArgument(fn_name, pos);
-    out = std::format("varSampIf({}, {})", expr, predicate);
+    out = std::format("IF (isNaN(varSampIf({0}, {1}) AS variance_{2}), 0, variance_{2})", expr, predicate, generateUniqueIdentifier());
 
     return true;
 }
 
 bool VarianceP::convertImpl(String & out, IParser::Pos & pos)
 {
-    return directMapping(out, pos, "varPop");
+    const String fn_name = getKQLFunctionName(pos);
+    if (fn_name.empty())
+        return false;
+
+    const String expr = getArgument(fn_name, pos);
+    out = std::format("IF (isNaN(varPop({0}) AS variance_{1}), 0, variance_{1})", expr, generateUniqueIdentifier());
+
+    return true;
 }
 
 bool CountDistinct::convertImpl(String & out, IParser::Pos & pos)

--- a/src/Parsers/tests/KQL/gtest_KQL_AggregateFunctions.cpp
+++ b/src/Parsers/tests/KQL/gtest_KQL_AggregateFunctions.cpp
@@ -111,18 +111,6 @@ INSTANTIATE_TEST_SUITE_P(ParserKQLQuery_Aggregate, ParserTest,
             "SELECT\n    FirstName,\n    LastName,\n    Age\nFROM Customers\nGROUP BY\n    FirstName,\n    LastName,\n    Age"
         },
         {
-            "Customers | summarize variance(Age)",
-            "SELECT varSamp(Age) AS variance_Age\nFROM Customers"
-        },
-        {
-            "Customers | summarize variancep(Age)",
-            "SELECT varPop(Age) AS variancep_Age\nFROM Customers"
-        },
-        {
-            "Customers | summarize varianceif(Age, Age < 30)",
-            "SELECT varSampIf(Age, Age < 30) AS varianceif_Age\nFROM Customers"
-        },
-        {
             "Customers | summarize z=arg_max(Age, FirstName, LastName) by Occupation",
             "SELECT\n    Occupation,\n    argMax(FirstName, Age) AS FirstName,\n    argMax(LastName, Age) AS LastName,\n    argMax(Age, Age) AS z\nFROM Customers\nGROUP BY Occupation"
         },
@@ -133,5 +121,23 @@ INSTANTIATE_TEST_SUITE_P(ParserKQLQuery_Aggregate, ParserTest,
         {
             "Customers | summarize x = hll(Education), y = hll(Occupation) | project xy = hll_merge(x, y) | project dcount_hll(xy);",
             "SELECT uniqCombined64Merge(18)(xy) AS Column1\nFROM\n(\n    SELECT uniqCombined64MergeState(18)(arrayJoin([x, y])) AS xy\n    FROM\n    (\n        SELECT\n            uniqCombined64State(18)(Education) AS x,\n            uniqCombined64State(18)(Occupation) AS y\n        FROM Customers\n    )\n)"
+        }
+})));
+
+INSTANTIATE_TEST_SUITE_P(ParserKQLQuery_Aggregate, ParserRegexTest,
+    ::testing::Combine(
+        ::testing::Values(std::make_shared<DB::ParserKQLStatement>()),
+        ::testing::ValuesIn(std::initializer_list<ParserTestCase>{
+        {
+            "Customers | summarize variance(Age)",
+            R"(SELECT IF\(isNaN\(varSamp\(Age\) AS variance_\d+\), 0, variance_\d+\) AS variance_Age\nFROM Customers)"
+        },
+        {
+            "Customers | summarize variancep(Age)",
+            R"(SELECT IF\(isNaN\(varPop\(Age\) AS variance_\d+\), 0, variance_\d+\) AS variancep_Age\nFROM Customers)"
+        },
+        {
+            "Customers | summarize varianceif(Age, Age < 30)",
+            R"(SELECT IF\(isNaN\(varSampIf\(Age, Age < 30\) AS variance_\d+\), 0, variance_\d+\) AS varianceif_Age\nFROM Customers)"
         }
 })));

--- a/src/Parsers/tests/KQL/gtest_KQL_AggregateFunctions.cpp
+++ b/src/Parsers/tests/KQL/gtest_KQL_AggregateFunctions.cpp
@@ -130,14 +130,14 @@ INSTANTIATE_TEST_SUITE_P(ParserKQLQuery_Aggregate, ParserRegexTest,
         ::testing::ValuesIn(std::initializer_list<ParserTestCase>{
         {
             "Customers | summarize variance(Age)",
-            R"(SELECT IF\(isNaN\(varSamp\(Age\) AS variance_\d+\), 0, variance_\d+\) AS variance_Age\nFROM Customers)"
+            R"(SELECT IF\(isNaN\(varSamp\(if\(toTypeName\(Age\) = \'Nullable\(Nothing\)\', throwIf\(toTypeName\(Age\) = \'Nullable\(Nothing\)\', \'summarize operator: Failed to resolve scalar expression named null\'\), Age\)\) AS variance_\d+\), 0, variance_\d+\) AS variance_Age\nFROM Customers)"
         },
         {
             "Customers | summarize variancep(Age)",
-            R"(SELECT IF\(isNaN\(varPop\(Age\) AS variance_\d+\), 0, variance_\d+\) AS variancep_Age\nFROM Customers)"
+            R"(SELECT IF\(isNaN\(varPop\(if\(toTypeName\(Age\) = \'Nullable\(Nothing\)\', throwIf\(toTypeName\(Age\) = \'Nullable\(Nothing\)\', \'summarize operator: Failed to resolve scalar expression named null\'\), Age\)\) AS variance_\d+\), 0, variance_\d+\) AS variancep_Age\nFROM Customers)"
         },
         {
             "Customers | summarize varianceif(Age, Age < 30)",
-            R"(SELECT IF\(isNaN\(varSampIf\(Age, Age < 30\) AS variance_\d+\), 0, variance_\d+\) AS varianceif_Age\nFROM Customers)"
+            R"(SELECT IF\(isNaN\(varSampIf\(if\(toTypeName\(Age\) = \'Nullable\(Nothing\)\', throwIf\(toTypeName\(Age\) = \'Nullable\(Nothing\)\', \'summarize operator: Failed to resolve scalar expression named null\'\), Age\), Age < 30\) AS variance_\d+\), 0, variance_\d+\) AS varianceif_Age\nFROM Customers)"
         }
 })));

--- a/tests/queries/0_stateless/02366_kql_summarize.sql
+++ b/tests/queries/0_stateless/02366_kql_summarize.sql
@@ -132,6 +132,9 @@ print '-- variance/variancep/varianceif --';
 Customers | summarize variance(Age);
 Customers | summarize variancep(Age);
 Customers | summarize varianceif(Age, Age < 30);
+Customers | summarize variance(null); -- { clientError Code: 395 }
+Customers | summarize variancep(null); -- { clientError Code: 395 }
+Customers | summarize varianceif(null, Age < 30); -- { clientError Code: 395 }
 
 print '-- arg_max --';
 Customers | summarize arg_max(Age); -- { clientError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }


### PR DESCRIPTION
This PR contains fix for two issues:
Issue: https://github.ibm.com/ClickHouse/issue-repo/issues/2517
Issue: https://github.ibm.com/ClickHouse/issue-repo/issues/2518


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Variance
```
BUbu1.fyre.ibm.com :) range x from 1 to 5 step -1 | summarize variance(x);

SELECT IF(isNaN(varSamp(x) AS variance_18250), 0, variance_18250) AS variance_x
FROM
(
    SELECT *
    FROM
    (
        SELECT kql_range(1, 5, -1) AS x
    )
    ARRAY JOIN x
)

Query id: 30b50fe2-630a-4ba6-9bee-b32f6898d6f4

┌─variance_x─┐
│          0 │
└────────────┘

1 row in set. Elapsed: 0.048 sec. 
```

VarianceP
```
BUbu1.fyre.ibm.com :) range x from 1 to 5 step -1 | summarize variancep(x);

SELECT IF(isNaN(varPop(x) AS variance_48065), 0, variance_48065) AS variancep_x
FROM
(
    SELECT *
    FROM
    (
        SELECT kql_range(1, 5, -1) AS x
    )
    ARRAY JOIN x
)

Query id: 186770c0-dbf9-4a50-8c8f-5b5851cdb528

┌─variancep_x─┐
│           0 │
└─────────────┘

1 row in set. Elapsed: 0.054 sec. 

```

VarianceIf
```
BUbu1.fyre.ibm.com :) range x from 1 to 5 step -1 | summarize varianceif(x, abs(x) > 0);

SELECT IF(isNaN(varSampIf(x, abs(x) > 0) AS variance_35694), 0, variance_35694) AS varianceif_x
FROM
(
    SELECT *
    FROM
    (
        SELECT kql_range(1, 5, -1) AS x
    )
    ARRAY JOIN x
)

Query id: cb0d9d8f-c04d-4104-94f1-09f2b7b116af

┌─varianceif_x─┐
│            0 │
└──────────────┘

1 row in set. Elapsed: 0.073 sec. 
```

