### PR TITLE
Fix codec delta endian issue for s390x

### DIFF
--- a/src/Compression/CompressionCodecDelta.cpp
+++ b/src/Compression/CompressionCodecDelta.cpp
@@ -73,8 +73,8 @@ void compressDataForType(const char * source, UInt32 source_size, char * dest)
     const char * const source_end = source + source_size;
     while (source < source_end)
     {
-        T curr_src = unalignedLoad<T>(source);
-        unalignedStore<T>(dest, curr_src - prev_src);
+        T curr_src = unalignedLoadLittleEndian<T>(source);
+        unalignedStoreLittleEndian<T>(dest, curr_src - prev_src);
         prev_src = curr_src;
 
         source += sizeof(T);
@@ -94,10 +94,10 @@ void decompressDataForType(const char * source, UInt32 source_size, char * dest,
     const char * const source_end = source + source_size;
     while (source < source_end)
     {
-        accumulator += unalignedLoad<T>(source);
+        accumulator += unalignedLoadLittleEndian<T>(source);
         if (dest + sizeof(accumulator) > output_end) [[unlikely]]
             throw Exception(ErrorCodes::CANNOT_DECOMPRESS, "Cannot decompress the data");
-        unalignedStore<T>(dest, accumulator);
+        unalignedStoreLittleEndian<T>(dest, accumulator);
 
         source += sizeof(T);
         dest += sizeof(T);


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
On s390x, codec delta has endian issue which fails the functional test `01375_compact_parts_codecs`.
The fix is to use LittleEndian to load/store data.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed codec delta endian issue in compression for s390x.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
