### PR TITLE
Fixed #2515 by modifying convertImpl for indexof_regex

### DIFF
--- a/src/Parsers/Kusto/KustoFunctions/KQLStringFunctions.cpp
+++ b/src/Parsers/Kusto/KustoFunctions/KQLStringFunctions.cpp
@@ -315,7 +315,26 @@ bool IndexOf::convertImpl(String & out, IParser::Pos & pos)
 
 bool IndexOfRegex::convertImpl(String & out, IParser::Pos & pos)
 {
-    return directMapping(out, pos, "kql_indexof_regex");
+    const auto fn_name = getKQLFunctionName(pos);
+    if (fn_name.empty())
+        return false;
+
+    const auto source = getArgument(fn_name, pos);
+    const auto lookup = getArgument(fn_name, pos);
+    const auto start_index = getOptionalArgument(fn_name, pos);
+    const auto length = getOptionalArgument(fn_name, pos);
+    const auto occurrence = getOptionalArgument(fn_name, pos);
+
+    out = std::format(
+        "If(isNULL({0}), -1, kql_indexof_regex(kql_tostring({0}),kql_tostring({1}),{2},{3},{4}))",
+        source,
+        lookup,
+        start_index.value_or("0"),
+        length.value_or("-1"),
+        occurrence.value_or("1"));
+
+    return true;
+    //return directMapping(out, pos, "kql_indexof_regex");
 }
 
 bool IsAscii::convertImpl(String & out, IParser::Pos & pos)

--- a/src/Parsers/Kusto/KustoFunctions/KQLStringFunctions.cpp
+++ b/src/Parsers/Kusto/KustoFunctions/KQLStringFunctions.cpp
@@ -334,7 +334,6 @@ bool IndexOfRegex::convertImpl(String & out, IParser::Pos & pos)
         occurrence.value_or("1"));
 
     return true;
-    //return directMapping(out, pos, "kql_indexof_regex");
 }
 
 bool IsAscii::convertImpl(String & out, IParser::Pos & pos)

--- a/src/Parsers/tests/KQL/gtest_KQL_StringFunctions.cpp
+++ b/src/Parsers/tests/KQL/gtest_KQL_StringFunctions.cpp
@@ -262,7 +262,7 @@ INSTANTIATE_TEST_SUITE_P(ParserKQLQuery_String, ParserTest,
         },
         {
             "table | project indexof_regex(A, B, C, D, E)",
-            "SELECT kql_indexof_regex(A, B, C, D, E) AS Column1\nFROM table"
+            "SELECT If(A IS NULL, -1, kql_indexof_regex(kql_tostring(A), kql_tostring(B), C, D, E)) AS Column1\nFROM table"
         },
         {
             "Customers | project t = isascii(FirstName)",

--- a/tests/queries/0_stateless/02366_kql_func_string.reference
+++ b/tests/queries/0_stateless/02366_kql_func_string.reference
@@ -428,6 +428,7 @@ Latoya	Shen	Professional	Graduate Degree	25
 -1
 -1
 \N
+-1
 2
 \N
 -1

--- a/tests/queries/0_stateless/02366_kql_func_string.sql
+++ b/tests/queries/0_stateless/02366_kql_func_string.sql
@@ -422,6 +422,7 @@ print idx2 = indexof_regex("abcabcdefg", "a.c", 0, 9, 2);
 print idx3 = indexof_regex("abcabc", "a.c", 1, -1, 2);
 print idx4 = indexof_regex("ababaa", "a.a", 0, -1, 2);
 print idx5 = indexof_regex("abcabc", "a|ab", -1);
+print idx6 = indexof_regex(int(null), '.');
 print indexof_regex('adsasdasasd', 'sas');
 print indexof_regex('adsasdasasd', 'sas', -1);
 print indexof_regex('adsasdasasd', 'sas', 99);


### PR DESCRIPTION
Issue: https://github.ibm.com/ClickHouse/issue-repo/issues/2515/

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Query 1:
`BUbu1.fyre.ibm.com :) print idx1 = indexof_regex(null, '.');`

```
SELECT If(NULL IS NULL, -1, kql_indexof_regex(kql_tostring(NULL), kql_tostring('.'), 0, -1, 1)) AS idx1

Query id: 964ed797-b175-46d6-9a0b-42385bb14bee

┌─idx1─┐
│   -1 │
└──────┘
```

Query 2:
`BUbu1.fyre.ibm.com :) print idx1 = indexof_regex(int(null), '.');`

```
SELECT If(if((toTypeName(NULL) = 'IntervalNanosecond') OR ((accurateCastOrNull(NULL, 'Int32') IS NULL) != (NULL IS NULL)), accurateCastOrNull(throwIf(true, 'Failed to parse Int32 literal'), 'Int32'), accurateCastOrNull(NULL, 'Int32')) IS NULL, -1, kql_indexof_regex(kql_tostring(if((toTypeName(NULL) = 'IntervalNanosecond') OR ((accurateCastOrNull(NULL, 'Int32') IS NULL) != (NULL IS NULL)), accurateCastOrNull(throwIf(true, 'Failed to parse Int32 literal'), 'Int32'), accurateCastOrNull(NULL, 'Int32'))), kql_tostring('.'), 0, -1, 1)) AS idx1

Query id: 61d74765-16f3-4489-8476-1848c52bb484

┌─idx1─┐
│   -1 │
└──────┘

```

Also, added Unit and Functional tests.