### PR TITLE
fix-3091 added simple mapping for constatnt expressions

### DIFF
--- a/src/Parsers/Kusto/KustoFunctions/IParserKQLFunction.cpp
+++ b/src/Parsers/Kusto/KustoFunctions/IParserKQLFunction.cpp
@@ -354,9 +354,16 @@ String IParserKQLFunction::getExpression(IParser::Pos & pos)
             array_index += getExpression(pos);
             ++pos;
         }
-        arg = std::format("[ {0} >=0 ? {0} + 1 : {0}]", array_index);
+        if (Int64 index; (boost::conversion::try_lexical_convert(array_index, index)))
+        {
+            auto ch_index = index >= 0 ? index + 1 : index;
+            arg = std::format("[{0}]", ch_index);
+        } 
+        else{
+            arg = std::format("[ {0} >=0 ? {0} + 1 : {0}]", array_index);
+        }
+        
     }
-
     return arg;
 }
 

--- a/src/Parsers/Kusto/KustoFunctions/IParserKQLFunction.cpp
+++ b/src/Parsers/Kusto/KustoFunctions/IParserKQLFunction.cpp
@@ -199,7 +199,13 @@ String IParserKQLFunction::getConvertedArgument(const String & fn_name, IParser:
                         array_index += getExpression(pos);
                         ++pos;
                     }
-                    token = std::format("[ {0} >=0 ? {0} + 1 : {0}]", array_index);
+                    if (Int64 index; (boost::conversion::try_lexical_convert(array_index, index)))
+                    {
+                        auto ch_index = index >= 0 ? index + 1 : index;
+                        token = std::format("[{0}]", ch_index);
+                    }
+                    else
+                        token = std::format("[ {0} >=0 ? {0} + 1 : {0}]", array_index);
                 }
                 else
                     token = String(pos->begin, pos->end);
@@ -358,11 +364,11 @@ String IParserKQLFunction::getExpression(IParser::Pos & pos)
         {
             auto ch_index = index >= 0 ? index + 1 : index;
             arg = std::format("[{0}]", ch_index);
-        } 
-        else{
+        }
+        else
+        {
             arg = std::format("[ {0} >=0 ? {0} + 1 : {0}]", array_index);
         }
-        
     }
     return arg;
 }

--- a/src/Parsers/tests/KQL/gtest_KQL_dynamicFunctions.cpp
+++ b/src/Parsers/tests/KQL/gtest_KQL_dynamicFunctions.cpp
@@ -110,12 +110,24 @@ INSTANTIATE_TEST_SUITE_P(ParserKQLQuery_Dynamic, ParserTest,
             "SELECT (A[1])[2] AS print_0"
         },
         {
+            "print A[-5]",
+            "SELECT A[-5] AS print_0"
+        },
+        {
+            "print A[-1][1]",
+            "SELECT (A[-1])[2] AS print_0"
+        },
+        {
             "print dynamic([[1,2,3,4,5],[20,30]])[0]",
             "SELECT [[1, 2, 3, 4, 5], [20, 30]][1] AS print_0"
         },
         {
             "print dynamic([[1,2,3,4,5],[20,30]])[1][1]",
             "SELECT ([[1, 2, 3, 4, 5], [20, 30]][2])[2] AS print_0"
+        },
+        {
+            "print dynamic([[1,2,3,4,5],[20,30]])[1][-1]",
+            "SELECT ([[1, 2, 3, 4, 5], [20, 30]][2])[-1] AS print_0"
         },
         {
             "print A[B[1]]",

--- a/src/Parsers/tests/KQL/gtest_KQL_dynamicFunctions.cpp
+++ b/src/Parsers/tests/KQL/gtest_KQL_dynamicFunctions.cpp
@@ -79,7 +79,7 @@ INSTANTIATE_TEST_SUITE_P(ParserKQLQuery_Dynamic, ParserTest,
         },
         {
             "print array_sort_asc(dynamic([2, 1, null,3]), dynamic([20, 10, 40, 30]))[0]",
-            "SELECT tupleElement(kql_array_sort_asc([2, 1, NULL, 3], [20, 10, 40, 30]), if(0 >= 0, 0 + 1, 0)) AS print_0"
+            "SELECT kql_array_sort_asc([2, 1, NULL, 3], [20, 10, 40, 30]).1 AS print_0"
         },
         {
             "print  (t) = array_sort_asc(dynamic([2, 1, null,3]), dynamic([20, 10, 40, 30]))",
@@ -103,23 +103,23 @@ INSTANTIATE_TEST_SUITE_P(ParserKQLQuery_Dynamic, ParserTest,
         },
         {
             "print A[0]",
-            "SELECT A[if(0 >= 0, 0 + 1, 0)] AS print_0"
+            "SELECT A[1] AS print_0"
         },
         {
             "print A[0][1]",
-            "SELECT (A[if(0 >= 0, 0 + 1, 0)])[if(1 >= 0, 1 + 1, 1)] AS print_0"
+            "SELECT (A[1])[2] AS print_0"
         },
         {
             "print dynamic([[1,2,3,4,5],[20,30]])[0]",
-            "SELECT [[1, 2, 3, 4, 5], [20, 30]][if(0 >= 0, 0 + 1, 0)] AS print_0"
+            "SELECT [[1, 2, 3, 4, 5], [20, 30]][1] AS print_0"
         },
         {
             "print dynamic([[1,2,3,4,5],[20,30]])[1][1]",
-            "SELECT ([[1, 2, 3, 4, 5], [20, 30]][if(1 >= 0, 1 + 1, 1)])[if(1 >= 0, 1 + 1, 1)] AS print_0"
+            "SELECT ([[1, 2, 3, 4, 5], [20, 30]][2])[2] AS print_0"
         },
         {
             "print A[B[1]]",
-            "SELECT A[if((B[if(1 >= 0, 1 + 1, 1)]) >= 0, (B[if(1 >= 0, 1 + 1, 1)]) + 1, B[if(1 >= 0, 1 + 1, 1)])] AS print_0"
+            "SELECT A[if((B[2]) >= 0, (B[2]) + 1, B[2])] AS print_0"
         },
         {
             "print A[strlen('a')-1]",
@@ -127,7 +127,7 @@ INSTANTIATE_TEST_SUITE_P(ParserKQLQuery_Dynamic, ParserTest,
         },
         {
             "print strlen(A[0])",
-            "SELECT lengthUTF8(A[if(0 >= 0, 0 + 1, 0)]) AS print_0"
+            "SELECT lengthUTF8(A[1]) AS print_0"
         },
         {
             "print repeat(1, 3)",


### PR DESCRIPTION
Issue: https://github.ibm.com/ClickHouse/issue-repo/issues/3091

### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Requirement was to add a direct mapping without using expression inside the array. Therefore, now computing the index first and then passing it to CH SQL only for constant numerical expressions.

Query:
`select * from kql(events | project custom_prop_value[0] | take 1)`

Output:
```
SELECT *
FROM
(
    SELECT custom_prop_value[1] AS Column1
    FROM events
    LIMIT 1
)
```
