### PR TITLE
Kusto-phase3: support arbitrary heredoc for kql table function

### DIFF
--- a/src/Parsers/Kusto/ParserKQLStatement.cpp
+++ b/src/Parsers/Kusto/ParserKQLStatement.cpp
@@ -70,10 +70,18 @@ bool ParserKQLTableFunction::parseImpl(Pos & pos, ASTPtr & node, Expected & expe
         if (pos->type == TokenType::HereDoc)
         {
             auto kal_table_str = String(pos->begin, pos->end);
-            size_t pos1 = kal_table_str.find("$$");
-            size_t pos2 = kal_table_str.rfind("$$");
-            if (pos1 != std::string::npos && pos2 != std::string::npos && pos1 < pos2)
-                kql_statement = kal_table_str.substr(pos1 + 2, pos2 - pos1 - 2);
+            auto heredoc_name_end_position = kal_table_str.find('$', 1);
+            if (heredoc_name_end_position != std::string::npos)
+            {
+                size_t heredoc_size = heredoc_name_end_position + 1;
+                std::string_view heredoc = {kal_table_str.data(), heredoc_size};
+
+                size_t heredoc_end_position = kal_table_str.find(heredoc, heredoc_size);
+                if (heredoc_end_position != std::string::npos)
+                {
+                    kql_statement = kal_table_str.substr(heredoc_name_end_position + 1, heredoc_end_position - heredoc_name_end_position - 1);
+                }
+            }
         }
         else
         {

--- a/src/Parsers/tests/KQL/gtest_KQL_operator_in_sql.cpp
+++ b/src/Parsers/tests/KQL/gtest_KQL_operator_in_sql.cpp
@@ -126,5 +126,9 @@ INSTANTIATE_TEST_SUITE_P(ParserKQLQuery_operator_in_sql, ParserTest,
         {
             "select * from kql($$print t = 'a' !in~ (dynamic(['A', 'b', 'c']))$$)",
             "SELECT *\nFROM\n(\n    SELECT lower('a') NOT IN (lower('A'), lower('b'), lower('c')) AS t\n)"
+        },
+        {
+            "select * from kql($IBM$print t = 'a' !in~ (dynamic(['A', 'b', 'c']))$IBM$)",
+            "SELECT *\nFROM\n(\n    SELECT lower('a') NOT IN (lower('A'), lower('b'), lower('c')) AS t\n)"
         }
 })));

--- a/tests/queries/0_stateless/02366_kql_operator_in_sql.reference
+++ b/tests/queries/0_stateless/02366_kql_operator_in_sql.reference
@@ -243,3 +243,4 @@ Peter	Nara	Skilled Manual	Graduate Degree	26
 20000
 0
 30000
+30000

--- a/tests/queries/0_stateless/02366_kql_operator_in_sql.sql
+++ b/tests/queries/0_stateless/02366_kql_operator_in_sql.sql
@@ -172,5 +172,6 @@ select * from kql($$StormEventsLite | where EventType has_cs 'Strong Wind' | cou
 select * from kql($$StormEventsLite | where EventType !has_cs 'iddqd' | count$$);
 select * from kql($$StormEventsLite | where EventType has_all ('iddqd', 'string') | count$$);
 select * from kql($$StormEventsLite | where EventType has_any ('iddqd', 'string') | count$$);
+select * from kql($IBM$StormEventsLite | where EventType has_any ('iddqd', 'string') | count$IBM$);
 DROP TABLE IF EXISTS Customers;
 drop table if exists StormEventsLite;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement

support arbitrary heredoc for kql table function

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
