### PR TITLE
Allowed space between number and unit in time span

### DIFF
--- a/src/Parsers/Kusto/ParserKQLTimespan.cpp
+++ b/src/Parsers/Kusto/ParserKQLTimespan.cpp
@@ -178,7 +178,7 @@ const auto SET_VALUE_AND_UNIT = [](auto & ctx)
 };
 
 const x3::rule<class KQLTimespanLiteral, KQLTimespanValueWithUnit> KQL_TIMESPAN_VALUE_WITH_UNIT = "KQL timespan value with unit";
-const auto KQL_TIMESPAN_VALUE_WITH_UNIT_def = (double_ >> timespan_units)[SET_VALUE_AND_UNIT];
+const auto KQL_TIMESPAN_VALUE_WITH_UNIT_def = (double_ >> lexeme[timespan_units])[SET_VALUE_AND_UNIT];
 
 const x3::rule<class KQLTimespanLiteral, Int64> KQL_TIMESPAN_DAY_VALUE = "KQL timespan day value";
 const auto KQL_TIMESPAN_DAY_VALUE_def = int_;
@@ -215,7 +215,7 @@ std::optional<Int64> ParserKQLTimespan::parse(const std::string_view expression)
     const auto * last = expression.cend();
 
     boost::variant<KQLTimespanComponents, KQLTimespanValueWithUnit, Int64, KQLTimespanNull> kql_timespan_variant;
-    const auto success = x3::parse(first, last, KQL_TIMESPAN, kql_timespan_variant);
+    const auto success = x3::phrase_parse(first, last, KQL_TIMESPAN, x3::space, kql_timespan_variant);
 
     if (!success || first != last)
         throw_exception();

--- a/src/Parsers/tests/KQL/gtest_KQL_StringFunctions.cpp
+++ b/src/Parsers/tests/KQL/gtest_KQL_StringFunctions.cpp
@@ -101,6 +101,22 @@ INSTANTIATE_TEST_SUITE_P(ParserKQLQuery_String, ParserTest,
             "SELECT toIntervalNanosecond(129600000000000) AS print_0"
         },
         {
+            "print time('1 d')",
+            "SELECT toIntervalNanosecond(86400000000000) AS print_0"
+        },
+        {
+            "print time('1.5 d')",
+            "SELECT toIntervalNanosecond(129600000000000) AS print_0"
+        },
+        {
+            "print time(1 h)",
+            "SELECT toIntervalNanosecond(3600000000000) AS print_0"
+        },
+        {
+            "print time(1 sec)",
+            "SELECT toIntervalNanosecond(1000000000) AS print_0"
+        },
+        {
             "print extract('x=([0-9.]+)', 1, 'hello x=456|wo' , typeof(bool));",
             "SELECT accurateCastOrNull(toInt64OrNull(kql_extract('hello x=456|wo', 'x=([0-9.]+)', 1)), 'Boolean') AS print_0"
         },


### PR DESCRIPTION
Issue: https://github.ibm.com/ClickHouse/issue-repo/issues/3149

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allowed space between number and unit in time span


- Example use: A query or command.
`print time(1 h)`
`SELECT toIntervalNanosecond(3600000000000) AS print_0`

