### PR TITLE
Implemented lookup_contains method for dictionaries in Kusto

### DIFF
--- a/src/Parsers/Kusto/KQL_ReleaseNote.md
+++ b/src/Parsers/Kusto/KQL_ReleaseNote.md
@@ -1,4 +1,11 @@
 ## KQL implemented features  
+# October, 2023
+## Features
+- Added lookup_contains('dict_name', value_to_search). This function returns a boolean value, specifically, True when value_to_search is found in the dictionary, and False otherwise.
+   ```
+   print lookup_contains('test_rocksDB',1);
+   ```
+
 # July, 2023
 ## Features
 -  Enable kql table function support both heredoc and regular format

--- a/src/Parsers/Kusto/KustoFunctions/KQLFunctionFactory.cpp
+++ b/src/Parsers/Kusto/KustoFunctions/KQLFunctionFactory.cpp
@@ -232,6 +232,7 @@ enum class KQLFunction : uint16_t
     iff,
     iif,
     lookup,
+    lookup_contains,
     gettype,
     not_,
 
@@ -503,6 +504,7 @@ const std::unordered_map<String, KQLFunction> KQL_FUNCTIONS{
     {"iff", KQLFunction::iff},
     {"iif", KQLFunction::iif},
     {"lookup", KQLFunction::lookup},
+    {"lookup_contains", KQLFunction::lookup_contains},
     {"gettype", KQLFunction::gettype},
     {"not", KQLFunction::not_},
 
@@ -1184,6 +1186,9 @@ std::unique_ptr<IParserKQLFunction> KQLFunctionFactory::get(const String & kql_f
 
         case KQLFunction::lookup:
             return std::make_unique<Lookup>();
+
+        case KQLFunction::lookup_contains:
+            return std::make_unique<LookupContains>();
 
         case KQLFunction::gettype:
             return std::make_unique<GetType>();

--- a/src/Parsers/Kusto/KustoFunctions/KQLGeneralFunctions.cpp
+++ b/src/Parsers/Kusto/KustoFunctions/KQLGeneralFunctions.cpp
@@ -39,6 +39,11 @@ bool Iif::convertImpl(String & out, IParser::Pos & pos)
     return directMapping(out, pos, "If");
 }
 
+bool LookupContains::convertImpl(String & out, IParser::Pos & pos)
+{
+    return directMapping(out, pos, "dictHas");
+}
+
 bool Lookup::convertImpl(String & out, IParser::Pos & pos)
 {
     auto temp_pos = pos;

--- a/src/Parsers/Kusto/KustoFunctions/KQLGeneralFunctions.h
+++ b/src/Parsers/Kusto/KustoFunctions/KQLGeneralFunctions.h
@@ -45,6 +45,13 @@ protected:
     bool convertImpl(String & out, IParser::Pos & pos) override;
 };
 
+class LookupContains : public IParserKQLFunction
+{
+protected:
+    const char * getName() const override { return "lookup_contains()"; }
+    bool convertImpl(String & out, IParser::Pos & pos) override;
+};
+
 class GetType : public IParserKQLFunction
 {
 protected:

--- a/src/Parsers/tests/KQL/gtest_KQL_General.cpp
+++ b/src/Parsers/tests/KQL/gtest_KQL_General.cpp
@@ -67,6 +67,10 @@ INSTANTIATE_TEST_SUITE_P(ParserKQLQuery_General, ParserTest,
             "SELECT dictGetOrDefault('dictionary_table', 'value', '100', 'default') AS print_0"
         },
         {
+            "print lookup_contains('dictionary_table', 1)",
+            "SELECT dictHas('dictionary_table', 1) AS print_0"
+        },
+        {
             "T | print 1",
             "throws AS print_0"
         },

--- a/tests/queries/0_stateless/02366_kql_func_general.reference
+++ b/tests/queries/0_stateless/02366_kql_func_general.reference
@@ -37,6 +37,8 @@ default
 10	First	1
 11	First	2
 12	First	3
+1
+0
 -- gettype
 string
 int

--- a/tests/queries/0_stateless/02366_kql_func_general.sql
+++ b/tests/queries/0_stateless/02366_kql_func_general.sql
@@ -60,6 +60,8 @@ print '-- lookup';
 print lookup('dictionary_table', 'value', '1');
 print lookup('dictionary_table', 'value', '100', 'default');
 dictionary_source_table | project start_range, t = lookup('dictionary_table', 'value', '1'), key;
+print lookup_contains('dictionary_table', '1');
+print lookup_contains('dictionary_table', '10');
 print '-- gettype';
 Customers | project t = gettype(FirstName) | limit 1;
 Customers | project t = gettype(Age) | limit 1;


### PR DESCRIPTION
Issue link: https://github.ibm.com/ClickHouse/issue-repo/issues/3276

### Changelog category (leave one):
- New Feature


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Added lookup_contains('dict_name', value_to_search). This function returns a boolean value, specifically, True when value_to_search is found in the dictionary, and False otherwise.


### Test
- Example use: A query or command.
`print lookup_contains('test_rocksDB',1);

SELECT dictHas('test_rocksDB', 1) AS print_0

Query id: 3a829b08-3fd5-4ebb-9b44-324e2d3961a2

┌─print_0─┐
│       1 │
└─────┘

1 row in set. Elapsed: 0.034 sec. `

`print lookup_contains('test_rocksDB',200);

SELECT dictHas('test_rocksDB', 200) AS print_0

Query id: b43ad552-20b1-41ca-bdd3-bb4cbb28676a

┌─print_0─┐
│       0 │
└─────┘

1 row in set. Elapsed: 0.030 sec. `

